### PR TITLE
Fix/[HCK-4592, HCK-4593] schema of a temporary sequence should not be specified in the ddl script

### DIFF
--- a/forward_engineering/ddlProvider/ddlHelpers/sequenceHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/sequenceHelper.js
@@ -64,7 +64,7 @@ module.exports = ({
 		 */
 		const optionConfigs = [
 			{ getOption, key: 'dataType', clause: 'AS', },
-			{ getOption, key: 'increment', clause: 'INCREMENT', },
+			{ getOption, key: 'increment', clause: 'INCREMENT BY', },
 			{ getOption, key: 'start', clause: 'START WITH', },
 			{ getOption, key: 'minValue', clause: 'MINVALUE', },
 			{ getOption, key: 'maxValue', clause: 'MAXVALUE', },

--- a/forward_engineering/ddlProvider/ddlHelpers/sequenceHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/sequenceHelper.js
@@ -37,9 +37,10 @@ module.exports = ({
 	 */
 	const getSequencesScript = (schemaName, sequences) => {
 		return _.map(sequences, (sequence) => {
+			const sequenceSchemaName = sequence.temporary ? '' : schemaName;
 			const name = getNamePrefixedWithSchemaName(
 				sequence.sequenceName,
-				schemaName
+				sequenceSchemaName
 			);
 			const ifNotExists = getIfNotExists(sequence);
 			const sequenceType = getSequenceType(sequence);


### PR DESCRIPTION
- For temporary sequences schema name should not be defined
- Added explicit define optional clause `BY` for `INCREMENT` option