### PR TITLE
HCK-4610: update the configuration to limit the number of 'owned by column' items

### DIFF
--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -242,7 +242,7 @@ making sure that you maintain a proper JSON format.
 						"template": "orderedList",
 						"propertyTooltip": "Causes the sequence to be associated with a specific table column, such that if that column (or its whole table) is dropped, the sequence will be automatically dropped as well. The specified table must have the same owner and be in the same schema as the sequence.",
 						"templateOptions": {
-							"maxFields": 1
+							"maxField": 1
 						},
 						"dependency": {
 							"key": "ownedByNone",


### PR DESCRIPTION
Updated the properties pane configuration to allow only one field to be selected in the 'Owned by Column' field.
The bucket level configuration used the `maxField` property to limit the number of fields that are allowed to be selected, whereas the entity and view level configuration used `maxFields`.