### PR TITLE
HCK-5124: Alter script must reflect the creation of an index on a newly created column or newly created table

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -105,8 +105,8 @@ const getAlterCollectionsScriptDtos = ({
     const createCollectionsScriptDtos = createScriptsData.filter(collection => collection.compMod?.created).map(getAddCollectionScriptDto({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
     const deleteCollectionScriptDtos = deleteScriptsData.filter(collection => collection.compMod?.deleted).map(getDeleteCollectionScriptDto(app));
     const modifyCollectionScriptDtos = modifyScriptsData.flatMap(getModifyCollectionScriptDtos({app, dbVersion}));
-    const addColumnScriptDtos = createScriptsData.flatMap(getAddColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
-    const deleteColumnScriptDtos = deleteScriptsData.flatMap(getDeleteColumnScriptDtos(app));
+    const addColumnScriptDtos = createScriptsData.filter(item => !item?.compMod?.created).flatMap(getAddColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
+    const deleteColumnScriptDtos = deleteScriptsData.filter(item => !item?.compMod?.deleted).flatMap(getDeleteColumnScriptDtos(app));
     const modifyColumnScriptDtos = modifyScriptsData.flatMap(getModifyColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
 
     return [

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -87,38 +87,27 @@ const getAlterCollectionsScriptDtos = ({
                                            internalDefinitions,
                                            externalDefinitions,
                                        }) => {
-    const createCollectionsScriptDtos = []
-        .concat(collection.properties?.entities?.properties?.added?.items)
-        .filter(Boolean)
-        .map(item => Object.values(item.properties)[0])
-        .filter(collection => collection.compMod?.created)
-        .map(getAddCollectionScriptDto({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
-    const deleteCollectionScriptDtos = []
-        .concat(collection.properties?.entities?.properties?.deleted?.items)
-        .filter(Boolean)
-        .map(item => Object.values(item.properties)[0])
-        .filter(collection => collection.compMod?.deleted)
-        .map(getDeleteCollectionScriptDto(app));
-    const modifyCollectionScriptDtos = []
-        .concat(collection.properties?.entities?.properties?.modified?.items)
-        .filter(Boolean)
-        .map(item => Object.values(item.properties)[0])
-        .flatMap(getModifyCollectionScriptDtos({app, dbVersion}));
-    const addColumnScriptDtos = []
-        .concat(collection.properties?.entities?.properties?.added?.items)
-        .filter(Boolean)
-        .map(item => Object.values(item.properties)[0])
-        .flatMap(getAddColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
-    const deleteColumnScriptDtos = []
-        .concat(collection.properties?.entities?.properties?.deleted?.items)
-        .filter(Boolean)
-        .map(item => Object.values(item.properties)[0])
-        .flatMap(getDeleteColumnScriptDtos(app));
-    const modifyColumnScriptDtos = []
-        .concat(collection.properties?.entities?.properties?.modified?.items)
-        .filter(Boolean)
-        .map(item => Object.values(item.properties)[0])
-        .flatMap(getModifyColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
+    const createScriptsData = []
+    .concat(collection.properties?.entities?.properties?.added?.items)
+    .filter(Boolean)
+    .map(item => Object.values(item.properties)[0])
+
+    const deleteScriptsData = []
+    .concat(collection.properties?.entities?.properties?.deleted?.items)
+    .filter(Boolean)
+    .map(item => Object.values(item.properties)[0])
+
+    const modifyScriptsData = []
+    .concat(collection.properties?.entities?.properties?.modified?.items)
+    .filter(Boolean)
+    .map(item => Object.values(item.properties)[0])
+
+    const createCollectionsScriptDtos = createScriptsData.filter(collection => collection.compMod?.created).map(getAddCollectionScriptDto({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
+    const deleteCollectionScriptDtos = deleteScriptsData.filter(collection => collection.compMod?.deleted).map(getDeleteCollectionScriptDto(app));
+    const modifyCollectionScriptDtos = modifyScriptsData.flatMap(getModifyCollectionScriptDtos({app, dbVersion}));
+    const addColumnScriptDtos = createScriptsData.flatMap(getAddColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
+    const deleteColumnScriptDtos = deleteScriptsData.flatMap(getDeleteColumnScriptDtos(app));
+    const modifyColumnScriptDtos = modifyScriptsData.flatMap(getModifyColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
 
     return [
         ...createCollectionsScriptDtos,

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -108,19 +108,16 @@ const getAlterCollectionsScriptDtos = ({
         .concat(collection.properties?.entities?.properties?.added?.items)
         .filter(Boolean)
         .map(item => Object.values(item.properties)[0])
-        .filter(collection => !collection.compMod)
         .flatMap(getAddColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
     const deleteColumnScriptDtos = []
         .concat(collection.properties?.entities?.properties?.deleted?.items)
         .filter(Boolean)
         .map(item => Object.values(item.properties)[0])
-        .filter(collection => !collection.compMod)
         .flatMap(getDeleteColumnScriptDtos(app));
     const modifyColumnScriptDtos = []
         .concat(collection.properties?.entities?.properties?.modified?.items)
         .filter(Boolean)
         .map(item => Object.values(item.properties)[0])
-        .filter(collection => !collection.compMod)
         .flatMap(getModifyColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
 
     return [

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -56,7 +56,7 @@ const getAddCollectionScriptDto =
             };
             const hydratedTable = ddlProvider.hydrateTable({tableData, entityData: [jsonSchema], jsonSchema});
 
-            const indexesOnNewlyCreatedColumnsScripts = getModifyIndexesScriptDtos({_, ddlProvider})({collection, dbVersion}).flatMap(({scripts}) => scripts.map(({script}) => script))
+            const indexesOnNewlyCreatedColumnsScripts = getIndexesBasedOnNewlyCreatedColumnsScript({_, ddlProvider, collection, dbVersion}).flatMap(({scripts}) => scripts.map(({script}) => script))
             const script = ddlProvider.createTable(hydratedTable, jsonSchema.isActivated);
             return AlterScriptDto.getInstance([script, ...indexesOnNewlyCreatedColumnsScripts], true, false)
         };

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -56,8 +56,9 @@ const getAddCollectionScriptDto =
             };
             const hydratedTable = ddlProvider.hydrateTable({tableData, entityData: [jsonSchema], jsonSchema});
 
+            const indexesOnNewlyCreatedColumnsScripts = getModifyIndexesScriptDtos({_, ddlProvider})({collection, dbVersion}).flatMap(({scripts}) => scripts.map(({script}) => script))
             const script = ddlProvider.createTable(hydratedTable, jsonSchema.isActivated);
-            return AlterScriptDto.getInstance([script], true, false)
+            return AlterScriptDto.getInstance([script, ...indexesOnNewlyCreatedColumnsScripts], true, false)
         };
 
 /**
@@ -109,7 +110,7 @@ const getAddColumnsByConditionScriptDtos =  ({app, dbVersion, modelDefinitions, 
         const fullName = getNamePrefixedWithSchemaName(tableName, schemaName);
         const schemaData = {schemaName, dbVersion};
 
-        return _.toPairs(collection.properties)
+        const scripts = _.toPairs(collection.properties)
             .filter(([name, jsonSchema]) => predicate([name, jsonSchema]))
             .map(([name, jsonSchema]) => {
                 const definitionJsonSchema = getDefinitionByReference({
@@ -130,9 +131,32 @@ const getAddColumnsByConditionScriptDtos =  ({app, dbVersion, modelDefinitions, 
             })
             .map(ddlProvider.convertColumnDefinition)
             .map(columnDefinition => ddlProvider.addColumn(fullName, columnDefinition))
-            .map(addColumnScript => AlterScriptDto.getInstance([addColumnScript], true, false))
-            .filter(Boolean);
+            .map(addColumnScript => AlterScriptDto.getInstance([addColumnScript], true, false));
+
+        const indexesOnNewlyCreatedColumns = getIndexesBasedOnNewlyCreatedColumnsScript({_, ddlProvider, collection})
+        return scripts.concat(indexesOnNewlyCreatedColumns).filter(Boolean)
     };
+
+/**
+ * 
+ * @return {AlterScriptDto[]}
+ * */
+const getIndexesBasedOnNewlyCreatedColumnsScript = ({_, ddlProvider, dbVersion, collection}) => {
+    const newIndexes = collection?.role?.compMod?.Indxs?.new || collection?.role?.Indxs || []
+    const newPropertiesIds = Object.values(collection?.properties).map(({GUID}) => GUID)
+
+    if (newIndexes.length === 0 || newPropertiesIds.length === 0) {
+        return []
+    }
+
+    const doAnyIndexUseNewlyCreatedColumn = newIndexes.some(({columns}) => columns.find(({keyId}) => newPropertiesIds.includes(keyId)))
+
+    if (!doAnyIndexUseNewlyCreatedColumn) {
+        return []
+    }
+
+    return getModifyIndexesScriptDtos({ _, ddlProvider })({ collection, dbVersion })
+}
 
 /**
  * @return {(collection: Object) => AlterScriptDto[]}

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
@@ -139,7 +139,7 @@ const getCreateIndexScriptDto = ({_, ddlProvider}) => ({index, collection, addit
  * }) => Array<AlterScriptDto>}
  * */
 const getAddedIndexesScriptDtos = ({_, ddlProvider}) => ({collection, additionalDataForDdlProvider}) => {
-    const newIndexes = collection?.role?.compMod?.Indxs?.new || [];
+    const newIndexes = collection?.role?.compMod?.Indxs?.new || collection?.role?.Indxs || [];
     const oldIndexes = collection?.role?.compMod?.Indxs?.old || [];
 
     return newIndexes

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
@@ -13,13 +13,15 @@ const {AlterScriptDto} = require("../../types/AlterScriptDto");
  * @return {({ columnId: string, collection: AlterCollectionDto }) => string | undefined}
  * */
 const getColumnNameById = ({_}) => ({columnId, collection}) => {
-    const nameToSchemaInProperties = _.toPairs(collection.role.properties || {})
-        .find(([fieldName, fieldJsonSchema]) => {
-            return fieldJsonSchema.GUID === columnId;
-        });
-    if (nameToSchemaInProperties?.length) {
-        return nameToSchemaInProperties[0];
+    const rolePropertiesEntries = _.toPairs(collection.role.properties || {}).map(([name, value]) => ({...value, name}))
+    const oldProperties = (collection?.role?.compMod?.oldProperties || []).map(property => ({...property, GUID: property.id}))
+    const properties = rolePropertiesEntries.length > 0 ? rolePropertiesEntries : oldProperties
+    const propertySchema = properties.find(fieldJsonSchema => fieldJsonSchema.GUID === columnId);
+
+    if (propertySchema) {
+        return propertySchema.name;
     }
+
     return undefined;
 }
 


### PR DESCRIPTION
Fixed issue with not generated alter script for created index right after creating a enw column or creating a table + new column + index