### PR TITLE
HCK-5356: Double "Create Index" and "Drop Index" statement in existing entities in ALTER script

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -7,7 +7,7 @@ const {getRenameColumnScriptDtos} = require("./columnHelpers/renameColumnHelper"
 const {AlterScriptDto} = require("../types/AlterScriptDto");
 const {AlterCollectionDto} = require('../types/AlterCollectionDto');
 const {getModifyPkConstraintsScriptDtos} = require("./entityHelpers/primaryKeyHelper");
-const {getModifyIndexesScriptDtos, getAddedIndexesScriptDtos} = require("./entityHelpers/indexesHelper");
+const {getModifyIndexesScriptDtos, getAddedIndexesScriptDtos, getAdditionalDataForDdlProvider} = require("./entityHelpers/indexesHelper");
 
 
 /**
@@ -155,13 +155,7 @@ const getIndexesBasedOnNewlyCreatedColumnsScript = ({_, ddlProvider, dbVersion, 
         return []
     }
 
-    const {getSchemaNameFromCollection} = require('../../utils/general')(_);
-    const additionalDataForDdlProvider = {
-        dbData: {dbVersion},
-        tableName: collection?.compMod?.collectionName?.new || collection?.role?.name || '',
-        schemaName: getSchemaNameFromCollection({collection}) || '',
-        isParentActivated: collection.isActivated,
-    }
+    const additionalDataForDdlProvider = getAdditionalDataForDdlProvider({_, dbVersion, collection})
 
     return getAddedIndexesScriptDtos({_, ddlProvider})({
         collection, additionalDataForDdlProvider

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -142,7 +142,7 @@ const getAddColumnsByConditionScriptDtos =  ({app, dbVersion, modelDefinitions, 
  * @return {AlterScriptDto[]}
  * */
 const getIndexesBasedOnNewlyCreatedColumnsScript = ({_, ddlProvider, dbVersion, collection}) => {
-    const newIndexes = collection?.role?.compMod?.Indxs?.new || collection?.role?.Indxs || []
+    const newIndexes = collection?.role?.Indxs || []
     const newPropertiesIds = Object.values(collection?.properties ?? {}).map(({GUID}) => GUID)
 
     if (newIndexes.length === 0 || newPropertiesIds.length === 0) {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -7,7 +7,7 @@ const {getRenameColumnScriptDtos} = require("./columnHelpers/renameColumnHelper"
 const {AlterScriptDto} = require("../types/AlterScriptDto");
 const {AlterCollectionDto} = require('../types/AlterCollectionDto');
 const {getModifyPkConstraintsScriptDtos} = require("./entityHelpers/primaryKeyHelper");
-const {getModifyIndexesScriptDtos} = require("./entityHelpers/indexesHelper");
+const {getModifyIndexesScriptDtos, getAddedIndexesScriptDtos} = require("./entityHelpers/indexesHelper");
 
 
 /**
@@ -155,7 +155,17 @@ const getIndexesBasedOnNewlyCreatedColumnsScript = ({_, ddlProvider, dbVersion, 
         return []
     }
 
-    return getModifyIndexesScriptDtos({ _, ddlProvider })({ collection, dbVersion })
+    const {getSchemaNameFromCollection} = require('../../utils/general')(_);
+    const additionalDataForDdlProvider = {
+        dbData: {dbVersion},
+        tableName: collection?.compMod?.collectionName?.new || collection?.role?.name || '',
+        schemaName: getSchemaNameFromCollection({collection}) || '',
+        isParentActivated: collection.isActivated,
+    }
+
+    return getAddedIndexesScriptDtos({_, ddlProvider})({
+        collection, additionalDataForDdlProvider
+    });
 }
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
@@ -141,7 +141,7 @@ const getCreateIndexScriptDto = ({_, ddlProvider}) => ({index, collection, addit
  * }) => Array<AlterScriptDto>}
  * */
 const getAddedIndexesScriptDtos = ({_, ddlProvider}) => ({collection, additionalDataForDdlProvider}) => {
-    const newIndexes = collection?.role?.compMod?.Indxs?.new || collection?.role?.Indxs || [];
+    const newIndexes = collection?.role?.Indxs || [];
     const oldIndexes = collection?.role?.compMod?.Indxs?.old || [];
 
     return newIndexes
@@ -347,4 +347,5 @@ const getModifyIndexesScriptDtos = ({_, ddlProvider}) => ({collection, dbVersion
 
 module.exports = {
     getModifyIndexesScriptDtos,
+    getAddedIndexesScriptDtos
 }

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
@@ -319,13 +319,7 @@ const getModifiedIndexesScriptDtos = ({_, ddlProvider}) => ({collection, additio
  * @return {({ collection: AlterCollectionDto, dbVersion: string }) => Array<AlterScriptDto>}
  * */
 const getModifyIndexesScriptDtos = ({_, ddlProvider}) => ({collection, dbVersion}) => {
-    const {getSchemaNameFromCollection} = require('../../../utils/general')(_);
-    const additionalDataForDdlProvider = {
-        dbData: {dbVersion},
-        tableName: collection?.compMod?.collectionName?.new || collection?.role?.name || '',
-        schemaName: getSchemaNameFromCollection({collection}) || '',
-        isParentActivated: collection.isActivated,
-    }
+    const additionalDataForDdlProvider = getAdditionalDataForDdlProvider({_, dbVersion, collection})
 
     const deletedIndexesScriptDtos = getDeletedIndexesScriptDtos({_, ddlProvider})({
         collection, additionalDataForDdlProvider
@@ -345,7 +339,19 @@ const getModifyIndexesScriptDtos = ({_, ddlProvider}) => ({collection, dbVersion
         .filter(Boolean);
 }
 
+const getAdditionalDataForDdlProvider = ({_, dbVersion, collection}) => {
+    const {getSchemaNameFromCollection} = require('../../../utils/general')(_);
+    
+    return {
+        dbData: {dbVersion},
+        tableName: collection?.compMod?.collectionName?.new || collection?.role?.name || '',
+        schemaName: getSchemaNameFromCollection({collection}) || '',
+        isParentActivated: collection.isActivated,
+    }
+}
+
 module.exports = {
     getModifyIndexesScriptDtos,
-    getAddedIndexesScriptDtos
+    getAddedIndexesScriptDtos,
+    getAdditionalDataForDdlProvider
 }


### PR DESCRIPTION
Removed invalid indexes source for new indexes and removed redundant indexes scripts generation on newly created columns