### PR TITLE
HCK-7351: fix alter script generation with an empty index

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -167,7 +167,7 @@ const getNewlyCreatedIndexesScripts = ({ _, ddlProvider, dbVersion, collection }
 		return [];
 	}
 
-	const doAnyIndexUseNewlyCreatedColumn = newIndexes.some(({ columns }) =>
+	const doAnyIndexUseNewlyCreatedColumn = newIndexes.some(({ columns = [] }) =>
 		columns.find(({ keyId }) => propertiesIds.includes(keyId)),
 	);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7351" title="HCK-7351" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7351</a>  Fix AlterScript FE with empty index
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

An index may not have the `columns` property.

...