### PR TITLE
[HCK-7941] Connecting twice after listing databases was failing on opening the ssh tunnel

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -38,6 +38,7 @@ module.exports = {
 
 	async getDatabases(connectionInfo, logger, cb, app) {
 		const sshService = app.require('@hackolade/ssh-service');
+		await postgresService.disconnect(sshService);
 
 		try {
 			logInfo('Get databases', connectionInfo, logger);
@@ -78,6 +79,9 @@ module.exports = {
 			});
 
 			postgresService.setDependencies(app);
+			if (!connectionInfo.ssh) {
+				await postgresService.connect(connectionInfo, sshService, postgresLogger);
+			}
 			await postgresService.logVersion();
 			const schemasNames = await postgresService.getAllSchemasNames();
 

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -78,7 +78,6 @@ module.exports = {
 			});
 
 			postgresService.setDependencies(app);
-			await postgresService.connect(connectionInfo, sshService, postgresLogger);
 			await postgresService.logVersion();
 			const schemasNames = await postgresService.getAllSchemasNames();
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7941" title="HCK-7941" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7941</a>  Fix Postgres ssh tunelling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

When trying to RE from an AWS RDS instance e.g. through ssh tunneling with an EC2 instance it's been discovered that the RE process was crashing.

<img width="650" alt="image" src="https://github.com/user-attachments/assets/605f0ab6-1bed-4afe-9a38-e4817640e8b5">

```{
    "message": "write EPIPE",
    "stack": "Error: write EPIPE\n    at target._send (node:internal/child_process:879:20)\n    at target.send (node:internal/child_process:752:19)\n    at callMethod (/Users/bigorn0/dev/hackolade/studio/services/workerService/createWorkerConsumer.js:52:10)\n    at /Users/bigorn0/dev/hackolade/studio/services/workerService/createWorkerConsumer.js:65:7\n    at new Promise (<anonymous>)\n    at Object.openTunnel (/Users/bigorn0/dev/hackolade/studio/services/workerService/createWorkerConsumer.js:64:6)\n    at createClient (/Users/bigorn0/.hackolade/plugins-develop/PostgreSQL/reverse_engineering/helpers/connectionHelper.js:64:40)\n    at Object.connect (/Users/bigorn0/.hackolade/plugins-develop/PostgreSQL/reverse_engineering/helpers/postgresService.js:74:41)\n    at async Object.getDbCollectionsNames (/Users/bigorn0/.hackolade/plugins-develop/PostgreSQL/reverse_engineering/api.js:81:4)\n    at async callApiHandler (/Users/bigorn0/dev/hackolade/studio/RE_API/helpers/callApiHandler.js:66:2)",
    "code": "EPIPE",
    "originalMessage": "write EPIPE"
}




Date: Tue Sep 10 2024 13:44:59 GMT+0200 (Central European Summer Time)
Application version: 7.7.8 (desktop)

System information:
 Hostname:  ub1home
 Platform:  darwin arm64
 Release:   23.5.0
 Version:   Darwin Kernel Version 23.5.0: Wed May  1 20:12:58 PDT 2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T6000
 Uptime:    973:29
 Total RAM: 16.00 GB
 CPU Model: Apple M1 Pro
 CPU Clock: 2400 MHZ
 CPU Cores: 10 cores

Application Information: 
Application version: 7.7.8 
Target: PostgreSQL 
Plugin version: 0.2.9
```

## Technical details

The connect function is currently trying to always setup the ssh tunnel when it's called thus the function can't be called twice in the same RE process because we try to re-setup the ssh tunnel twice and it's failing with a weird error. (Maybe it means we need a better connectivity management but that's another story...).