### PR TITLE
HCK-8149: use PK or UK constraint for relationship parent field

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,14 @@
                 "disablePipelines": true
             },
             "relationships": {
-                "compositeRelationships": true
+                "compositeRelationships": {
+                    "allowRelationshipsByProperties": [
+                        "primaryKey",
+                        "unique",
+                        "compositeUniqueKey",
+                        "compositePrimaryKey"
+                    ]
+                }
             },
             "FEScriptCommentsSupported": true,
             "enableFetchSystemEntitiesCheckbox": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8149" title="HCK-8149" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8149</a>  PostgreSQL: Use Unique constraint of the parent field while creating relationship
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

A relationship parent field should be:
- a PK or
- a part of composite PK or
- UK or
- a part of composite PK
