### PR TITLE
HCK-9147: add adapting for unvailable types

### DIFF
--- a/properties_pane/model_level/modelLevelConfig.json
+++ b/properties_pane/model_level/modelLevelConfig.json
@@ -71,7 +71,25 @@ making sure that you maintain a proper JSON format.
 				"propertyTooltip": "DB version",
 				"propertyType": "select",
 				"options": ["v10.x", "v11.x", "v12.x", "v13.x", "v14.x", "v15.x", "v16.x"],
-				"disabledOption": false
+				"disabledOption": false,
+				"adapters": [
+					{
+						"dependency": {
+							"type": "or",
+							"values": [
+								{
+									"key": "dbVersion",
+									"value": "v10.x"
+								},
+								{
+									"key": "dbVersion",
+									"value": "v11.x"
+								}
+							]
+						},
+						"adapter": "adaptUnavailableTypes"
+					}
+				]
 			},
 			{
 				"propertyName": "Database name",

--- a/types/vector.json
+++ b/types/vector.json
@@ -30,6 +30,11 @@
 			"childValueMode": "real"
 		}
 	},
+	"compatibleWith": {
+		"type": "char",
+		"parentType": "string",
+		"mode": "bit"
+	},
 	"dependency": {
 		"type": "not",
 		"values": [


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9147" title="HCK-9147" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9147</a>  [PG versions] Adapter for automatic vector columns conversions on PG model version update which does not have vector support
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
