### PR TITLE
HCK-9128: Handle indexes without name in PostgreSQL

### DIFF
--- a/forward_engineering/ddlProvider/ddlHelpers/indexHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/indexHelper.js
@@ -94,6 +94,10 @@ const getValue = value => {
 };
 
 const createIndex = (tableName, index, dbData, isParentActivated = true) => {
+	if (!index.columns.length) {
+		return '';
+	}
+
 	const isUnique = index.unique && index.index_method === 'btree';
 	const name = wrapInQuotes(index.indxName);
 	const unique = isUnique ? ' UNIQUE' : '';

--- a/forward_engineering/ddlProvider/ddlHelpers/indexHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/indexHelper.js
@@ -94,7 +94,9 @@ const getValue = value => {
 };
 
 const createIndex = (tableName, index, dbData, isParentActivated = true) => {
-	if (!index.columns.length) {
+	const isNameEmpty = !index.indxName && index.ifNotExist;
+
+	if (!index.columns.length || isNameEmpty) {
 		return '';
 	}
 

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -883,7 +883,24 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Name",
 						"propertyKeyword": "indxName",
 						"propertyTooltip": "Optional, if not specified an automatic name will be assigned. Index name are needed to drop indexes and appear in error messages when a constraint is violated.",
-						"propertyType": "text"
+						"propertyType": "text",
+						"dependency": {
+							"key": "ifNotExist",
+							"value": false
+						}
+					},
+					{
+						"propertyName": "Name",
+						"propertyKeyword": "indxName",
+						"propertyTooltip": "",
+						"propertyType": "text",
+						"validation": {
+							"required": true
+						},
+						"dependency": {
+							"key": "ifNotExist",
+							"value": true
+						}
 					},
 					{
 						"propertyName": "Activated",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -1024,6 +1024,10 @@ making sure that you maintain a proper JSON format.
 						"dependency": {
 							"key": "index_method",
 							"value": "btree"
+						},
+						"validation": {
+							"required": true,
+							"minLength": 1
 						}
 					},
 					{
@@ -1068,6 +1072,10 @@ making sure that you maintain a proper JSON format.
 									"value": "brin"
 								}
 							]
+						},
+						"validation": {
+							"required": true,
+							"minLength": 1
 						}
 					},
 					{

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -885,8 +885,13 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Optional, if not specified an automatic name will be assigned. Index name are needed to drop indexes and appear in error messages when a constraint is violated.",
 						"propertyType": "text",
 						"dependency": {
-							"key": "ifNotExist",
-							"value": false
+							"type": "not",
+							"values": [
+								{
+									"key": "ifNotExist",
+									"value": true
+								}
+							]
 						}
 					},
 					{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9128" title="HCK-9128" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9128</a>  Handle indexes without name in all SQL-like targets, depending whether name is mandatory or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated validation of required fields in the "Create Index" script
- index name is required only if "IF NOT EXIST" specified
- columns are required