### PR TITLE
HCK-10531: add hasMaxLength conversion for varbit

### DIFF
--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -67,6 +67,15 @@
 				"to": {
 					"hasMaxLength": true
 				}
+			},
+			{
+				"from": {
+					"mode": "varbit",
+					"length": 10485760
+				},
+				"to": {
+					"hasMaxLength": true
+				}
 			}
 		]
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10531" title="HCK-10531" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10531</a>  [PostgreSQL] Char Max length. Incorrect conversion of max value to Polyglot (no max)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added hasMaxLength conversion for varbit