### PR TITLE
HCK-11497: add adapter to deconstruct array on derive and construct it on convert

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -189,7 +189,86 @@
 				"to": {
 					"length": 10485760
 				}
-			}
+			},
+			[
+				"deconstructArrayIntoArrayType",
+				{
+					"arrayDependency": {
+						"type": "or",
+						"values": [
+							{
+								"type": "and",
+								"values": [
+									{
+										"key": "type",
+										"value": "array"
+									},
+									{
+										"key": "childType",
+										"value": "array"
+									}
+								]
+							},
+							{
+								"type": "and",
+								"values": [
+									{
+										"key": "type",
+										"value": "array"
+									},
+									{
+										"key": "childType",
+										"value": "list"
+									}
+								]
+							},
+							{
+								"type": "and",
+								"values": [
+									{
+										"key": "type",
+										"value": "array"
+									},
+									{
+										"key": "childType",
+										"value": "set"
+									}
+								]
+							},
+							{
+								"type": "and",
+								"values": [
+									{
+										"key": "type",
+										"value": "array"
+									},
+									{
+										"key": "childType",
+										"value": "tuple"
+									}
+								]
+							}
+						]
+					},
+					"childDependency": {
+						"type": "not",
+						"values": {
+							"type": "or",
+							"values": [
+								{
+									"key": "type",
+									"value": "document"
+								},
+								{
+									"key": "type",
+									"value": "array"
+								}
+							]
+						}
+					},
+					"keyword": "array_type"
+				}
+			]
 		]
 	},
 	"postConvert": {

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -76,7 +76,18 @@
 				"to": {
 					"hasMaxLength": true
 				}
-			}
+			},
+			[
+				"constructArrayFromArrayType",
+				{
+					"dependency": {
+						"key": "array_type",
+						"exist": true
+					},
+					"keywordOfArrayType": "array_type",
+					"typeOfPolyglotArray": "array"
+				}
+			]
 		]
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11497" title="HCK-11497" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-11497</a>  Fix derive of arrays into PostgreSQL as array type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

* On derive we need to convert array into a column with "Array type"
* On convert we need to convert a column with "Array type" into array (or multiple arrays) with array item of column's type