### PR TITLE
HCK-11990: add additional properties config for json data type

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -5913,7 +5913,8 @@ making sure that you maintain a proper JSON format.
 						"value": true
 					}
 				]
-			}
+			},
+			"additionalProperties"
 		],
 		"vector": [
 			"name",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11990" title="HCK-11990" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-11990</a>  [Derive from Poly][PostgreSQL] Derived from Poly entity object type and 'additionalProperties' set to false is not forwarded with to the JSON Schema
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
