### PR TITLE
HCK-12339: Add options on existing SINGLE UK/PK should be in delta model alter script

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/areConstraintOptionsEqual.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/areConstraintOptionsEqual.js
@@ -1,0 +1,18 @@
+const _ = require('lodash');
+const { AlterCollectionColumnKeyOptionDto } = require('../../types/AlterCollectionDto');
+
+/**
+ * @param {Array<Partial<AlterCollectionColumnKeyOptionDto>>} oldConstraintOptions
+ * @param {Array<Partial<AlterCollectionColumnKeyOptionDto>>} constraintOptions
+ * @returns {boolean}
+ */
+const areConstraintOptionsEqual = (oldConstraintOptions = [], constraintOptions = []) => {
+	return (
+		oldConstraintOptions.length === constraintOptions.length &&
+		_(oldConstraintOptions).differenceWith(constraintOptions, _.isEqual).isEmpty()
+	);
+};
+
+module.exports = {
+	areConstraintOptionsEqual,
+};

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -7,7 +7,7 @@ const {
 	AlterCollectionColumnKeyOptionDto,
 	AlterCollectionRoleCompModPrimaryKey,
 } = require('../../types/AlterCollectionDto');
-const { KeyTransitionDto, KeyScriptModificationDto } = require('../../types/AlterKeyDto');
+const { PrimaryKeyTransitionDto, KeyScriptModificationDto } = require('../../types/AlterKeyDto');
 const {
 	getFullCollectionName,
 	getSchemaOfAlterCollection,
@@ -62,7 +62,7 @@ const getCustomPropertiesOfCompositePkForComparisonWithRegularPkOptions = compos
 
 /**
  * @param {AlterCollectionDto} collection
- * @return {KeyTransitionDto}
+ * @return {PrimaryKeyTransitionDto}
  * */
 const wasCompositePkChangedInTransitionFromCompositeToRegular = collection => {
 	/**
@@ -77,18 +77,18 @@ const wasCompositePkChangedInTransitionFromCompositeToRegular = collection => {
 	if (idsOfColumns.length !== amountOfColumnsInRegularPk) {
 		// We return false, because it wouldn't count as transition between regular PK and composite PK
 		// if composite PK did not constraint exactly 1 column
-		return KeyTransitionDto.noTransition();
+		return PrimaryKeyTransitionDto.noTransition();
 	}
 	const idOfPkColumn = idsOfColumns[0];
 	const newColumnJsonSchema = Object.values(collection.properties).find(
 		columnJsonSchema => columnJsonSchema.GUID === idOfPkColumn,
 	);
 	if (!newColumnJsonSchema) {
-		return KeyTransitionDto.noTransition();
+		return PrimaryKeyTransitionDto.noTransition();
 	}
 	const isNewColumnARegularPrimaryKey = newColumnJsonSchema?.primaryKey && !newColumnJsonSchema?.compositePrimaryKey;
 	if (!isNewColumnARegularPrimaryKey) {
-		return KeyTransitionDto.noTransition();
+		return PrimaryKeyTransitionDto.noTransition();
 	}
 	const constraintOptions = getCustomPropertiesOfRegularPkForComparisonWithRegularPkOptions(newColumnJsonSchema);
 	const areOptionsEqual = oldPrimaryKeys.some(compositePk => {
@@ -100,12 +100,12 @@ const wasCompositePkChangedInTransitionFromCompositeToRegular = collection => {
 		return _(oldCompositePkAsRegularPkOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
 	});
 
-	return KeyTransitionDto.transition(!areOptionsEqual);
+	return PrimaryKeyTransitionDto.transition(!areOptionsEqual);
 };
 
 /**
  * @param {AlterCollectionDto} collection
- * @return {KeyTransitionDto}
+ * @return {PrimaryKeyTransitionDto}
  * */
 const wasCompositePkChangedInTransitionFromRegularToComposite = collection => {
 	/**
@@ -120,18 +120,18 @@ const wasCompositePkChangedInTransitionFromRegularToComposite = collection => {
 	if (idsOfColumns.length !== amountOfColumnsInRegularPk) {
 		// We return false, because it wouldn't count as transition between regular PK and composite PK
 		// if composite PK does not constraint exactly 1 column
-		return KeyTransitionDto.noTransition();
+		return PrimaryKeyTransitionDto.noTransition();
 	}
 	const idOfPkColumn = idsOfColumns[0];
 	const oldColumnJsonSchema = Object.values(collection.role.properties).find(
 		columnJsonSchema => columnJsonSchema.GUID === idOfPkColumn,
 	);
 	if (!oldColumnJsonSchema) {
-		return KeyTransitionDto.noTransition();
+		return PrimaryKeyTransitionDto.noTransition();
 	}
 	const isOldColumnARegularPrimaryKey = oldColumnJsonSchema?.primaryKey && !oldColumnJsonSchema?.compositePrimaryKey;
 	if (!isOldColumnARegularPrimaryKey) {
-		return KeyTransitionDto.noTransition();
+		return PrimaryKeyTransitionDto.noTransition();
 	}
 	const constraintOptions = getCustomPropertiesOfRegularPkForComparisonWithRegularPkOptions(oldColumnJsonSchema);
 	const areOptionsEqual = newPrimaryKeys.some(compositePk => {
@@ -143,7 +143,7 @@ const wasCompositePkChangedInTransitionFromRegularToComposite = collection => {
 		return _(oldCompositePkAsRegularPkOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
 	});
 
-	return KeyTransitionDto.transition(!areOptionsEqual);
+	return PrimaryKeyTransitionDto.transition(!areOptionsEqual);
 };
 
 /**
@@ -410,7 +410,7 @@ const wasFieldChangedToBeARegularPk = (columnJsonSchema, collection) => {
 /**
  * @param {AlterCollectionColumnDto} columnJsonSchema
  * @param {AlterCollectionDto} collection
- * @return {KeyTransitionDto}
+ * @return {PrimaryKeyTransitionDto}
  * */
 const wasRegularPkChangedInTransitionFromCompositeToRegular = (columnJsonSchema, collection) => {
 	const oldName = columnJsonSchema.compMod.oldField.name;
@@ -420,7 +420,7 @@ const wasRegularPkChangedInTransitionFromCompositeToRegular = (columnJsonSchema,
 	const wasTheFieldAnyPrimaryKey = Boolean(oldColumnJsonSchema?.primaryKey);
 
 	if (!(isRegularPrimaryKey && wasTheFieldAnyPrimaryKey)) {
-		return KeyTransitionDto.noTransition();
+		return PrimaryKeyTransitionDto.noTransition();
 	}
 
 	/**
@@ -454,16 +454,16 @@ const wasRegularPkChangedInTransitionFromCompositeToRegular = (columnJsonSchema,
 				getCustomPropertiesOfCompositePkForComparisonWithRegularPkOptions(oldCompositePk);
 			return _(oldCompositePkAsRegularPkOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
 		});
-		return KeyTransitionDto.transition(!areOptionsEqual);
+		return PrimaryKeyTransitionDto.transition(!areOptionsEqual);
 	}
 
-	return KeyTransitionDto.noTransition();
+	return PrimaryKeyTransitionDto.noTransition();
 };
 
 /**
  * @param {AlterCollectionColumnDto} columnJsonSchema
  * @param {AlterCollectionDto} collection
- * @return {KeyTransitionDto}
+ * @return {PrimaryKeyTransitionDto}
  * */
 const wasRegularPkChangedInTransitionFromRegularToComposite = (columnJsonSchema, collection) => {
 	const oldName = columnJsonSchema.compMod.oldField.name;
@@ -473,7 +473,7 @@ const wasRegularPkChangedInTransitionFromRegularToComposite = (columnJsonSchema,
 	const isTheFieldAnyPrimaryKey = Boolean(columnJsonSchema?.primaryKey);
 
 	if (!(wasRegularPrimaryKey && isTheFieldAnyPrimaryKey)) {
-		return KeyTransitionDto.noTransition();
+		return PrimaryKeyTransitionDto.noTransition();
 	}
 
 	/**
@@ -507,10 +507,10 @@ const wasRegularPkChangedInTransitionFromRegularToComposite = (columnJsonSchema,
 				getCustomPropertiesOfCompositePkForComparisonWithRegularPkOptions(oldCompositePk);
 			return _(oldCompositePkAsRegularPkOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
 		});
-		return KeyTransitionDto.transition(!areOptionsEqual);
+		return PrimaryKeyTransitionDto.transition(!areOptionsEqual);
 	}
 
-	return KeyTransitionDto.noTransition();
+	return PrimaryKeyTransitionDto.noTransition();
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -15,6 +15,7 @@ const {
 	wrapInQuotes,
 } = require('../../../utils/general');
 const { alterKeyConstraint, dropKeyConstraint } = require('../../../ddlProvider/ddlHelpers/constraintsHelper');
+const { areConstraintOptionsEqual } = require('./areConstraintOptionsEqual');
 
 const amountOfColumnsInRegularPk = 1;
 
@@ -97,7 +98,8 @@ const wasCompositePkChangedInTransitionFromCompositeToRegular = collection => {
 		}
 		const oldCompositePkAsRegularPkOptions =
 			getCustomPropertiesOfCompositePkForComparisonWithRegularPkOptions(compositePk);
-		return _(oldCompositePkAsRegularPkOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
+
+		return areConstraintOptionsEqual(oldCompositePkAsRegularPkOptions, constraintOptions);
 	});
 
 	return PrimaryKeyTransitionDto.transition(!areOptionsEqual);
@@ -140,7 +142,8 @@ const wasCompositePkChangedInTransitionFromRegularToComposite = collection => {
 		}
 		const oldCompositePkAsRegularPkOptions =
 			getCustomPropertiesOfCompositePkForComparisonWithRegularPkOptions(compositePk);
-		return _(oldCompositePkAsRegularPkOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
+
+		return areConstraintOptionsEqual(oldCompositePkAsRegularPkOptions, constraintOptions);
 	});
 
 	return PrimaryKeyTransitionDto.transition(!areOptionsEqual);
@@ -452,7 +455,8 @@ const wasRegularPkChangedInTransitionFromCompositeToRegular = (columnJsonSchema,
 			}
 			const oldCompositePkAsRegularPkOptions =
 				getCustomPropertiesOfCompositePkForComparisonWithRegularPkOptions(oldCompositePk);
-			return _(oldCompositePkAsRegularPkOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
+
+			return areConstraintOptionsEqual(oldCompositePkAsRegularPkOptions, constraintOptions);
 		});
 		return PrimaryKeyTransitionDto.transition(!areOptionsEqual);
 	}
@@ -505,7 +509,8 @@ const wasRegularPkChangedInTransitionFromRegularToComposite = (columnJsonSchema,
 			}
 			const oldCompositePkAsRegularPkOptions =
 				getCustomPropertiesOfCompositePkForComparisonWithRegularPkOptions(oldCompositePk);
-			return _(oldCompositePkAsRegularPkOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
+
+			return areConstraintOptionsEqual(oldCompositePkAsRegularPkOptions, constraintOptions);
 		});
 		return PrimaryKeyTransitionDto.transition(!areOptionsEqual);
 	}
@@ -545,8 +550,8 @@ const wasRegularPkModified = (columnJsonSchema, collection) => {
 	}
 	const constraintOptions = getCustomPropertiesOfRegularPkForComparisonWithRegularPkOptions(columnJsonSchema);
 	const oldConstraintOptions = getCustomPropertiesOfRegularPkForComparisonWithRegularPkOptions(oldJsonSchema);
-	const areOptionsEqual = _(oldConstraintOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
-	return !areOptionsEqual;
+
+	return !areConstraintOptionsEqual(oldConstraintOptions, constraintOptions);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -17,6 +17,7 @@ const {
 	getDbVersion,
 	wrapInQuotes,
 } = require('../../../utils/general');
+const { areConstraintOptionsEqual } = require('./areConstraintOptionsEqual');
 
 const amountOfColumnsInRegularUniqueKey = 1;
 
@@ -100,7 +101,8 @@ const wasCompositeUniqueKeyChangedInTransitionFromCompositeToRegular = collectio
 		}
 		const oldCompositeUniqueKeyAsRegularUniqueKeyOptions =
 			getCustomPropertiesOfCompositeUniqueKeyForComparisonWithRegularUniqueKeyOptions(compositeUniqueKey);
-		return _(oldCompositeUniqueKeyAsRegularUniqueKeyOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
+
+		return areConstraintOptionsEqual(oldCompositeUniqueKeyAsRegularUniqueKeyOptions, constraintOptions);
 	});
 
 	return UniqueKeyTransitionDto.transition(!areOptionsEqual);
@@ -144,7 +146,8 @@ const wasCompositeUniqueKeyChangedInTransitionFromRegularToComposite = collectio
 		}
 		const oldCompositeUniqueKeyAsRegularUniqueKeyOptions =
 			getCustomPropertiesOfCompositeUniqueKeyForComparisonWithRegularUniqueKeyOptions(compositeUniqueKey);
-		return _(oldCompositeUniqueKeyAsRegularUniqueKeyOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
+
+		return areConstraintOptionsEqual(oldCompositeUniqueKeyAsRegularUniqueKeyOptions, constraintOptions);
 	});
 
 	return UniqueKeyTransitionDto.transition(!areOptionsEqual);
@@ -584,8 +587,8 @@ const wasRegularUniqueKeyModified = (columnJsonSchema, collection) => {
 		getCustomPropertiesOfRegularUniqueKeyForComparisonWithRegularUniqueKeyOptions(columnJsonSchema);
 	const oldConstraintOptions =
 		getCustomPropertiesOfRegularUniqueKeyForComparisonWithRegularUniqueKeyOptions(oldJsonSchema);
-	const areOptionsEqual = _(oldConstraintOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
-	return !areOptionsEqual;
+
+	return !areConstraintOptionsEqual(oldConstraintOptions, constraintOptions);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -39,6 +39,7 @@ const extractOptionsForComparisonWithRegularUniqueKeyOptions = optionHolder => {
 		indexStorageParameters: optionHolder.indexStorageParameters,
 		indexTablespace: optionHolder.indexTablespace,
 		indexInclude: optionHolder.indexInclude,
+		nullsDistinct: optionHolder.nullsDistinct,
 	};
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -7,7 +7,7 @@ const {
 	AlterCollectionColumnKeyOptionDto,
 	AlterCollectionRoleCompModUniqueKey,
 } = require('../../types/AlterCollectionDto');
-const { KeyTransitionDto, KeyScriptModificationDto } = require('../../types/AlterKeyDto');
+const { UniqueKeyTransitionDto, KeyScriptModificationDto } = require('../../types/AlterKeyDto');
 const { dropKeyConstraint, alterKeyConstraint } = require('../../../ddlProvider/ddlHelpers/constraintsHelper');
 const keyHelper = require('../../../ddlProvider/ddlHelpers/keyHelper');
 const {
@@ -64,7 +64,7 @@ const getCustomPropertiesOfCompositeUniqueKeyForComparisonWithRegularUniqueKeyOp
 
 /**
  * @param {AlterCollectionDto} collection
- * @return {KeyTransitionDto}
+ * @return {UniqueKeyTransitionDto}
  * */
 const wasCompositeUniqueKeyChangedInTransitionFromCompositeToRegular = collection => {
 	/**
@@ -79,18 +79,18 @@ const wasCompositeUniqueKeyChangedInTransitionFromCompositeToRegular = collectio
 	if (idsOfColumns.length !== amountOfColumnsInRegularUniqueKey) {
 		// We return false, because it wouldn't count as transition between regular UniqueKey and composite UniqueKey
 		// if composite UniqueKey did not constraint exactly 1 column
-		return KeyTransitionDto.noTransition();
+		return UniqueKeyTransitionDto.noTransition();
 	}
 	const idOfUniqueKeyColumn = idsOfColumns[0];
 	const newColumnJsonSchema = Object.values(collection.properties).find(
 		columnJsonSchema => columnJsonSchema.GUID === idOfUniqueKeyColumn,
 	);
 	if (!newColumnJsonSchema) {
-		return KeyTransitionDto.noTransition();
+		return UniqueKeyTransitionDto.noTransition();
 	}
 	const isNewColumnARegularUniqueKey = newColumnJsonSchema?.unique && !newColumnJsonSchema?.compositeUniqueKey;
 	if (!isNewColumnARegularUniqueKey) {
-		return KeyTransitionDto.noTransition();
+		return UniqueKeyTransitionDto.noTransition();
 	}
 	const constraintOptions =
 		getCustomPropertiesOfRegularUniqueKeyForComparisonWithRegularUniqueKeyOptions(newColumnJsonSchema);
@@ -103,12 +103,12 @@ const wasCompositeUniqueKeyChangedInTransitionFromCompositeToRegular = collectio
 		return _(oldCompositeUniqueKeyAsRegularUniqueKeyOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
 	});
 
-	return KeyTransitionDto.transition(!areOptionsEqual);
+	return UniqueKeyTransitionDto.transition(!areOptionsEqual);
 };
 
 /**
  * @param {AlterCollectionDto} collection
- * @return {KeyTransitionDto}
+ * @return {UniqueKeyTransitionDto}
  * */
 const wasCompositeUniqueKeyChangedInTransitionFromRegularToComposite = collection => {
 	/**
@@ -123,18 +123,18 @@ const wasCompositeUniqueKeyChangedInTransitionFromRegularToComposite = collectio
 	if (idsOfColumns.length !== amountOfColumnsInRegularUniqueKey) {
 		// We return false, because it wouldn't count as transition between regular UniqueKey and composite UniqueKey
 		// if composite UniqueKey does not constraint exactly 1 column
-		return KeyTransitionDto.noTransition();
+		return UniqueKeyTransitionDto.noTransition();
 	}
 	const idOfUniqueKeyColumn = idsOfColumns[0];
 	const oldColumnJsonSchema = Object.values(collection.role.properties).find(
 		columnJsonSchema => columnJsonSchema.GUID === idOfUniqueKeyColumn,
 	);
 	if (!oldColumnJsonSchema) {
-		return KeyTransitionDto.noTransition();
+		return UniqueKeyTransitionDto.noTransition();
 	}
 	const isOldColumnARegularUniqueKey = oldColumnJsonSchema?.unique && !oldColumnJsonSchema?.compositeUniqueKey;
 	if (!isOldColumnARegularUniqueKey) {
-		return KeyTransitionDto.noTransition();
+		return UniqueKeyTransitionDto.noTransition();
 	}
 	const constraintOptions =
 		getCustomPropertiesOfRegularUniqueKeyForComparisonWithRegularUniqueKeyOptions(oldColumnJsonSchema);
@@ -147,7 +147,7 @@ const wasCompositeUniqueKeyChangedInTransitionFromRegularToComposite = collectio
 		return _(oldCompositeUniqueKeyAsRegularUniqueKeyOptions).differenceWith(constraintOptions, _.isEqual).isEmpty();
 	});
 
-	return KeyTransitionDto.transition(!areOptionsEqual);
+	return UniqueKeyTransitionDto.transition(!areOptionsEqual);
 };
 
 /**
@@ -441,7 +441,7 @@ const wasFieldChangedToBeARegularUniqueKey = (columnJsonSchema, collection) => {
 /**
  * @param {AlterCollectionColumnDto} columnJsonSchema
  * @param {AlterCollectionDto} collection
- * @return {KeyTransitionDto}
+ * @return {UniqueKeyTransitionDto}
  * */
 const wasRegularUniqueKeyChangedInTransitionFromCompositeToRegular = (columnJsonSchema, collection) => {
 	const oldName = columnJsonSchema.compMod.oldField.name;
@@ -451,7 +451,7 @@ const wasRegularUniqueKeyChangedInTransitionFromCompositeToRegular = (columnJson
 	const wasTheFieldAnyUniqueKey = oldColumnJsonSchema?.unique || oldColumnJsonSchema.compositeUniqueKey;
 
 	if (!(isRegularUniqueKey && wasTheFieldAnyUniqueKey)) {
-		return KeyTransitionDto.noTransition();
+		return UniqueKeyTransitionDto.noTransition();
 	}
 
 	/**
@@ -488,16 +488,16 @@ const wasRegularUniqueKeyChangedInTransitionFromCompositeToRegular = (columnJson
 				.differenceWith(constraintOptions, _.isEqual)
 				.isEmpty();
 		});
-		return KeyTransitionDto.transition(!areOptionsEqual);
+		return UniqueKeyTransitionDto.transition(!areOptionsEqual);
 	}
 
-	return KeyTransitionDto.noTransition();
+	return UniqueKeyTransitionDto.noTransition();
 };
 
 /**
  * @param {AlterCollectionColumnDto} columnJsonSchema
  * @param {AlterCollectionDto} collection
- * @return {KeyTransitionDto}
+ * @return {UniqueKeyTransitionDto}
  * */
 const wasRegularUniqueKeyChangedInTransitionFromRegularToComposite = (columnJsonSchema, collection) => {
 	const oldName = columnJsonSchema.compMod.oldField.name;
@@ -507,7 +507,7 @@ const wasRegularUniqueKeyChangedInTransitionFromRegularToComposite = (columnJson
 	const isTheFieldAnyUniqueKey = Boolean(columnJsonSchema?.unique);
 
 	if (!(wasRegularUniqueKey && isTheFieldAnyUniqueKey)) {
-		return KeyTransitionDto.noTransition();
+		return UniqueKeyTransitionDto.noTransition();
 	}
 
 	/**
@@ -544,10 +544,10 @@ const wasRegularUniqueKeyChangedInTransitionFromRegularToComposite = (columnJson
 				.differenceWith(constraintOptions, _.isEqual)
 				.isEmpty();
 		});
-		return KeyTransitionDto.transition(!areOptionsEqual);
+		return UniqueKeyTransitionDto.transition(!areOptionsEqual);
 	}
 
-	return KeyTransitionDto.noTransition();
+	return UniqueKeyTransitionDto.noTransition();
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -487,9 +487,8 @@ const wasRegularUniqueKeyChangedInTransitionFromCompositeToRegular = (columnJson
 			}
 			const oldCompositeUniqueKeyAsRegularUniqueKeyOptions =
 				getCustomPropertiesOfCompositeUniqueKeyForComparisonWithRegularUniqueKeyOptions(oldCompositeUniqueKey);
-			return _(oldCompositeUniqueKeyAsRegularUniqueKeyOptions)
-				.differenceWith(constraintOptions, _.isEqual)
-				.isEmpty();
+
+			return areConstraintOptionsEqual(oldCompositeUniqueKeyAsRegularUniqueKeyOptions, constraintOptions);
 		});
 		return UniqueKeyTransitionDto.transition(!areOptionsEqual);
 	}
@@ -543,10 +542,10 @@ const wasRegularUniqueKeyChangedInTransitionFromRegularToComposite = (columnJson
 			}
 			const oldCompositeUniqueKeyAsRegularUniqueKeyOptions =
 				getCustomPropertiesOfCompositeUniqueKeyForComparisonWithRegularUniqueKeyOptions(oldCompositeUniqueKey);
-			return _(oldCompositeUniqueKeyAsRegularUniqueKeyOptions)
-				.differenceWith(constraintOptions, _.isEqual)
-				.isEmpty();
+
+			return areConstraintOptionsEqual(oldCompositeUniqueKeyAsRegularUniqueKeyOptions, constraintOptions);
 		});
+
 		return UniqueKeyTransitionDto.transition(!areOptionsEqual);
 	}
 

--- a/forward_engineering/alterScript/types/AlterKeyDto.js
+++ b/forward_engineering/alterScript/types/AlterKeyDto.js
@@ -5,11 +5,6 @@ class KeyTransitionDto {
 	didTransitionHappen;
 
 	/**
-	 * @type {boolean | undefined}
-	 * */
-	wasPkChangedInTransition;
-
-	/**
 	 * @return {KeyTransitionDto}
 	 * */
 	static noTransition() {
@@ -19,13 +14,47 @@ class KeyTransitionDto {
 	}
 
 	/**
-	 * @param {boolean} wasPkChangedInTransition
 	 * @return {KeyTransitionDto}
+	 * */
+	static transition() {
+		return {
+			didTransitionHappen: true,
+		};
+	}
+}
+
+class PrimaryKeyTransitionDto extends KeyTransitionDto {
+	/**
+	 * @type {boolean | undefined}
+	 * */
+	wasPkChangedInTransition;
+
+	/**
+	 * @param {boolean} wasPkChangedInTransition
+	 * @return {PrimaryKeyTransitionDto}
 	 * */
 	static transition(wasPkChangedInTransition) {
 		return {
 			didTransitionHappen: true,
 			wasPkChangedInTransition,
+		};
+	}
+}
+
+class UniqueKeyTransitionDto extends KeyTransitionDto {
+	/**
+	 * @type {boolean | undefined}
+	 * */
+	wasUniqueKeyChangedInTransition;
+
+	/**
+	 * @param {boolean} wasUniqueKeyChangedInTransition
+	 * @return {UniqueKeyTransitionDto}
+	 * */
+	static transition(wasUniqueKeyChangedInTransition) {
+		return {
+			didTransitionHappen: true,
+			wasUniqueKeyChangedInTransition,
 		};
 	}
 }
@@ -67,5 +96,6 @@ class KeyScriptModificationDto {
 
 module.exports = {
 	KeyScriptModificationDto,
-	KeyTransitionDto,
+	PrimaryKeyTransitionDto,
+	UniqueKeyTransitionDto,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12339" title="HCK-12339" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12339</a>  Add options on existing SINGLE UK/PK should be in delta model alter script
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

- If previous options were empty, checking for option changes gave incorrect result.
- Added missed `wasUniqueKeyChangedInTransition` property when changing the key type