### PR TITLE
HCK-12532: fix "create index" duplicates

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -147,8 +147,7 @@ const getAddColumnsByConditionScriptDtos =
 			.map(columnDefinition => ddlProvider.addColumn(fullName, columnDefinition))
 			.map(addColumnScript => AlterScriptDto.getInstance([addColumnScript], true, false));
 
-		const indexesOnNewlyCreatedColumns = getNewlyCreatedIndexesScripts({ dbVersion, collection });
-		return scripts.concat(indexesOnNewlyCreatedColumns).filter(Boolean);
+		return scripts.filter(Boolean);
 	};
 
 /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12532" title="HCK-12532" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12532</a>  [DeltaModel][PostgreSQL]: Double "create index" statement
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Keys handled by collection modifications ([it was fixed in the studio](https://github.com/hackolade/studio/pull/3784)). But statements are duplicated because they are also handled by the added columns. Keep statements handled only by collection modifications. The added columns should generate SQL only to add the columns.