### PR TITLE
HCK-13023: if no key in composite PK/UK then default to empty array

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -76,7 +76,7 @@ const wasCompositePkChangedInTransitionFromCompositeToRegular = collection => {
 	 * @type {AlterCollectionRoleCompModPKDto[]}
 	 * */
 	const oldPrimaryKeys = pkDto.old || [];
-	const idsOfColumns = oldPrimaryKeys.flatMap(pk => pk.compositePrimaryKey.map(dto => dto.keyId));
+	const idsOfColumns = oldPrimaryKeys.flatMap(pk => pk.compositePrimaryKey?.map(dto => dto.keyId) || []);
 	if (idsOfColumns.length !== amountOfColumnsInRegularPk) {
 		// We return false, because it wouldn't count as transition between regular PK and composite PK
 		// if composite PK did not constraint exactly 1 column
@@ -120,7 +120,7 @@ const wasCompositePkChangedInTransitionFromRegularToComposite = collection => {
 	 * @type {AlterCollectionRoleCompModPKDto[]}
 	 * */
 	const newPrimaryKeys = pkDto.new || [];
-	const idsOfColumns = newPrimaryKeys.flatMap(pk => pk.compositePrimaryKey.map(dto => dto.keyId));
+	const idsOfColumns = newPrimaryKeys.flatMap(pk => pk.compositePrimaryKey?.map(dto => dto.keyId) || []);
 	if (idsOfColumns.length !== amountOfColumnsInRegularPk) {
 		// We return false, because it wouldn't count as transition between regular PK and composite PK
 		// if composite PK does not constraint exactly 1 column

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -79,7 +79,7 @@ const wasCompositeUniqueKeyChangedInTransitionFromCompositeToRegular = collectio
 	 * @type {AlterCollectionRoleCompModUniqueKeyDto[]}
 	 * */
 	const oldUniqueKeys = uniqueDto.old || [];
-	const idsOfColumns = oldUniqueKeys.flatMap(unique => unique.compositeUniqueKey.map(dto => dto.keyId));
+	const idsOfColumns = oldUniqueKeys.flatMap(unique => unique.compositeUniqueKey?.map(dto => dto.keyId) || []);
 	if (idsOfColumns.length !== amountOfColumnsInRegularUniqueKey) {
 		// We return false, because it wouldn't count as transition between regular UniqueKey and composite UniqueKey
 		// if composite UniqueKey did not constraint exactly 1 column
@@ -124,7 +124,7 @@ const wasCompositeUniqueKeyChangedInTransitionFromRegularToComposite = collectio
 	 * @type {AlterCollectionRoleCompModUniqueKeyDto[]}
 	 * */
 	const newUniqueKeys = uniqueDto.new || [];
-	const idsOfColumns = newUniqueKeys.flatMap(unique => unique.compositeUniqueKey.map(dto => dto.keyId));
+	const idsOfColumns = newUniqueKeys.flatMap(unique => unique.compositeUniqueKey?.map(dto => dto.keyId) || []);
 	if (idsOfColumns.length !== amountOfColumnsInRegularUniqueKey) {
 		// We return false, because it wouldn't count as transition between regular UniqueKey and composite UniqueKey
 		// if composite UniqueKey does not constraint exactly 1 column


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13023" title="HCK-13023" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13023</a>  [PostreSQL] ERROR in FE tab if PK without key specified
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

1. If the list of keys is undefined (empty composite PK), `.map` fails.
2. Default to empty arr (`[]`) for empty composite PKs.