### PR TITLE
fix: some keys might be null/undefined after cleanup

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -95,7 +95,7 @@ const wasCompositePkChangedInTransitionFromCompositeToRegular = collection => {
 	}
 	const constraintOptions = getCustomPropertiesOfRegularPkForComparisonWithRegularPkOptions(newColumnJsonSchema);
 	const areOptionsEqual = oldPrimaryKeys.some(compositePk => {
-		if (compositePk.compositePrimaryKey.length !== amountOfColumnsInRegularPk) {
+		if (compositePk.compositePrimaryKey?.length !== amountOfColumnsInRegularPk) {
 			return false;
 		}
 		const oldCompositePkAsRegularPkOptions =
@@ -139,7 +139,7 @@ const wasCompositePkChangedInTransitionFromRegularToComposite = collection => {
 	}
 	const constraintOptions = getCustomPropertiesOfRegularPkForComparisonWithRegularPkOptions(oldColumnJsonSchema);
 	const areOptionsEqual = newPrimaryKeys.some(compositePk => {
-		if (compositePk.compositePrimaryKey.length !== amountOfColumnsInRegularPk) {
+		if (compositePk.compositePrimaryKey?.length !== amountOfColumnsInRegularPk) {
 			return false;
 		}
 		const oldCompositePkAsRegularPkOptions =
@@ -187,7 +187,7 @@ const getCreateCompositePKDDLProviderConfig = (primaryKey, entityName, entity) =
 	const constraintName = getConstraintNameForCompositePk(primaryKey, entityName);
 	const pkColumns = _.toPairs(entity.role.properties)
 		.filter(([name, jsonSchema]) =>
-			Boolean(primaryKey.compositePrimaryKey.find(keyDto => keyDto.keyId === jsonSchema.GUID)),
+			Boolean(primaryKey.compositePrimaryKey?.find(keyDto => keyDto.keyId === jsonSchema.GUID)),
 		)
 		.map(([name, jsonSchema]) => ({
 			name,
@@ -444,10 +444,10 @@ const wasRegularPkChangedInTransitionFromCompositeToRegular = (columnJsonSchema,
 	 * */
 	const oldPrimaryKeys = pkDto.old || [];
 	const wasTheFieldACompositePrimaryKey = oldPrimaryKeys.some(compPk =>
-		compPk.compositePrimaryKey.some(pk => pk.keyId === oldColumnJsonSchema.GUID),
+		compPk.compositePrimaryKey?.some(pk => pk.keyId === oldColumnJsonSchema.GUID),
 	);
 	const isTheFieldACompositePrimaryKey = newPrimaryKeys.some(compPk =>
-		compPk.compositePrimaryKey.some(pk => pk.keyId === columnJsonSchema.GUID),
+		compPk.compositePrimaryKey?.some(pk => pk.keyId === columnJsonSchema.GUID),
 	);
 
 	const wasCompositePkRemoved = wasTheFieldACompositePrimaryKey && !isTheFieldACompositePrimaryKey;
@@ -458,7 +458,7 @@ const wasRegularPkChangedInTransitionFromCompositeToRegular = (columnJsonSchema,
 		// to amount of regular pk columns, we must recreate PK
 		const constraintOptions = getCustomPropertiesOfRegularPkForComparisonWithRegularPkOptions(columnJsonSchema);
 		const areOptionsEqual = oldPrimaryKeys.some(oldCompositePk => {
-			if (oldCompositePk.compositePrimaryKey.length !== amountOfColumnsInRegularPk) {
+			if (oldCompositePk.compositePrimaryKey?.length !== amountOfColumnsInRegularPk) {
 				return false;
 			}
 			const oldCompositePkAsRegularPkOptions =
@@ -498,10 +498,10 @@ const wasRegularPkChangedInTransitionFromRegularToComposite = (columnJsonSchema,
 	 * */
 	const oldPrimaryKeys = pkDto.old || [];
 	const wasTheFieldACompositePrimaryKey = oldPrimaryKeys.some(compPk =>
-		compPk.compositePrimaryKey.some(pk => pk.keyId === oldColumnJsonSchema.GUID),
+		compPk.compositePrimaryKey?.some(pk => pk.keyId === oldColumnJsonSchema.GUID),
 	);
 	const isTheFieldACompositePrimaryKey = newPrimaryKeys.some(compPk =>
-		compPk.compositePrimaryKey.some(pk => pk.keyId === columnJsonSchema.GUID),
+		compPk.compositePrimaryKey?.some(pk => pk.keyId === columnJsonSchema.GUID),
 	);
 
 	const wasCompositePkAdded = isTheFieldACompositePrimaryKey && !wasTheFieldACompositePrimaryKey;
@@ -512,7 +512,7 @@ const wasRegularPkChangedInTransitionFromRegularToComposite = (columnJsonSchema,
 		// to amount of regular pk columns, we must recreate PK
 		const constraintOptions = getCustomPropertiesOfRegularPkForComparisonWithRegularPkOptions(oldColumnJsonSchema);
 		const areOptionsEqual = newPrimaryKeys.some(oldCompositePk => {
-			if (oldCompositePk.compositePrimaryKey.length !== amountOfColumnsInRegularPk) {
+			if (oldCompositePk.compositePrimaryKey?.length !== amountOfColumnsInRegularPk) {
 				return false;
 			}
 			const oldCompositePkAsRegularPkOptions =

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -99,7 +99,7 @@ const wasCompositeUniqueKeyChangedInTransitionFromCompositeToRegular = collectio
 	const constraintOptions =
 		getCustomPropertiesOfRegularUniqueKeyForComparisonWithRegularUniqueKeyOptions(newColumnJsonSchema);
 	const areOptionsEqual = oldUniqueKeys.some(compositeUniqueKey => {
-		if (compositeUniqueKey.compositeUniqueKey.length !== amountOfColumnsInRegularUniqueKey) {
+		if (compositeUniqueKey.compositeUniqueKey?.length !== amountOfColumnsInRegularUniqueKey) {
 			return false;
 		}
 		const oldCompositeUniqueKeyAsRegularUniqueKeyOptions =
@@ -144,7 +144,7 @@ const wasCompositeUniqueKeyChangedInTransitionFromRegularToComposite = collectio
 	const constraintOptions =
 		getCustomPropertiesOfRegularUniqueKeyForComparisonWithRegularUniqueKeyOptions(oldColumnJsonSchema);
 	const areOptionsEqual = newUniqueKeys.some(compositeUniqueKey => {
-		if (compositeUniqueKey.compositeUniqueKey.length !== amountOfColumnsInRegularUniqueKey) {
+		if (compositeUniqueKey.compositeUniqueKey?.length !== amountOfColumnsInRegularUniqueKey) {
 			return false;
 		}
 		const oldCompositeUniqueKeyAsRegularUniqueKeyOptions =
@@ -192,7 +192,7 @@ const getCreateCompositeUniqueKeyDDLProviderConfig = (uniqueKey, entityName, ent
 	const constraintName = getConstraintNameForCompositeUniqueKey(uniqueKey, entityName);
 	const uniqueColumns = _.toPairs(entity.role.properties)
 		.filter(([name, jsonSchema]) =>
-			Boolean(uniqueKey.compositeUniqueKey.find(keyDto => keyDto.keyId === jsonSchema.GUID)),
+			Boolean(uniqueKey.compositeUniqueKey?.find(keyDto => keyDto.keyId === jsonSchema.GUID)),
 		)
 		.map(([name, jsonSchema]) => ({
 			name,
@@ -476,10 +476,10 @@ const wasRegularUniqueKeyChangedInTransitionFromCompositeToRegular = (columnJson
 	 * */
 	const oldUniqueKeys = uniqueDto.old || [];
 	const wasTheFieldACompositeUniqueKey = oldUniqueKeys.some(compUniqueKey =>
-		compUniqueKey.compositeUniqueKey.some(unique => unique.keyId === oldColumnJsonSchema.GUID),
+		compUniqueKey.compositeUniqueKey?.some(unique => unique.keyId === oldColumnJsonSchema.GUID),
 	);
 	const isTheFieldACompositeUniqueKey = newUniqueKeys.some(compUniqueKey =>
-		compUniqueKey.compositeUniqueKey.some(unique => unique.keyId === columnJsonSchema.GUID),
+		compUniqueKey.compositeUniqueKey?.some(unique => unique.keyId === columnJsonSchema.GUID),
 	);
 
 	const wasCompositeUniqueKeyRemoved = wasTheFieldACompositeUniqueKey && !isTheFieldACompositeUniqueKey;
@@ -491,7 +491,7 @@ const wasRegularUniqueKeyChangedInTransitionFromCompositeToRegular = (columnJson
 		const constraintOptions =
 			getCustomPropertiesOfRegularUniqueKeyForComparisonWithRegularUniqueKeyOptions(columnJsonSchema);
 		const areOptionsEqual = oldUniqueKeys.some(oldCompositeUniqueKey => {
-			if (oldCompositeUniqueKey.compositeUniqueKey.length !== amountOfColumnsInRegularUniqueKey) {
+			if (oldCompositeUniqueKey.compositeUniqueKey?.length !== amountOfColumnsInRegularUniqueKey) {
 				return false;
 			}
 			const oldCompositeUniqueKeyAsRegularUniqueKeyOptions =
@@ -531,10 +531,10 @@ const wasRegularUniqueKeyChangedInTransitionFromRegularToComposite = (columnJson
 	 * */
 	const oldUniqueKeys = uniqueDto.old || [];
 	const wasTheFieldACompositeUniqueKey = oldUniqueKeys.some(compUniqueKey =>
-		compUniqueKey.compositeUniqueKey.some(unique => unique.keyId === oldColumnJsonSchema.GUID),
+		compUniqueKey.compositeUniqueKey?.some(unique => unique.keyId === oldColumnJsonSchema.GUID),
 	);
 	const isTheFieldACompositeUniqueKey = newUniqueKeys.some(compUniqueKey =>
-		compUniqueKey.compositeUniqueKey.some(unique => unique.keyId === columnJsonSchema.GUID),
+		compUniqueKey.compositeUniqueKey?.some(unique => unique.keyId === columnJsonSchema.GUID),
 	);
 
 	const wasCompositeUniqueKeyAdded = isTheFieldACompositeUniqueKey && !wasTheFieldACompositeUniqueKey;
@@ -546,7 +546,7 @@ const wasRegularUniqueKeyChangedInTransitionFromRegularToComposite = (columnJson
 		const constraintOptions =
 			getCustomPropertiesOfRegularUniqueKeyForComparisonWithRegularUniqueKeyOptions(oldColumnJsonSchema);
 		const areOptionsEqual = newUniqueKeys.some(oldCompositeUniqueKey => {
-			if (oldCompositeUniqueKey.compositeUniqueKey.length !== amountOfColumnsInRegularUniqueKey) {
+			if (oldCompositeUniqueKey.compositeUniqueKey?.length !== amountOfColumnsInRegularUniqueKey) {
 				return false;
 			}
 			const oldCompositeUniqueKeyAsRegularUniqueKeyOptions =


### PR DESCRIPTION
## Technical details

Found during testing: https://hackolade.atlassian.net/browse/HCK-13023

The cleanup process might remove the keys, making them null/undefined. Use optional.