### PR TITLE
HCK-13030: ignore generating FK/UK if no columns

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -259,10 +259,13 @@ const getAddCompositePkScriptDtos = collection => {
 	return newPrimaryKeys
 		.map(newPk => {
 			const ddlConfig = getCreateCompositePKDDLProviderConfig(newPk, entityName, collection);
+			if (_.isEmpty(ddlConfig.columns)) {
+				return null;
+			}
 			const statementDto = alterKeyConstraint(fullTableName, isCollectionActivated, ddlConfig);
 			return new KeyScriptModificationDto(statementDto.statement, fullTableName, false, statementDto.isActivated);
 		})
-		.filter(scriptDto => Boolean(scriptDto.script));
+		.filter(scriptDto => Boolean(scriptDto?.script));
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -277,10 +277,13 @@ const getAddCompositeUniqueKeyScriptDtos = (collection, dbVersion) => {
 				collection,
 				dbVersion,
 			);
+			if (_.isEmpty(ddlConfig.columns)) {
+				return null;
+			}
 			const statementDto = alterKeyConstraint(fullTableName, isCollectionActivated, ddlConfig);
 			return new KeyScriptModificationDto(statementDto.statement, fullTableName, false, statementDto.isActivated);
 		})
-		.filter(scriptDto => Boolean(scriptDto.script));
+		.filter(scriptDto => Boolean(scriptDto?.script));
 };
 
 /**

--- a/forward_engineering/ddlProvider/ddlHelpers/constraintsHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/constraintsHelper.js
@@ -69,8 +69,14 @@ const foreignActiveKeysToString = keys => {
  * }}
  * */
 const createKeyConstraint = (templates, isParentActivated) => keyData => {
-	const constraintName = wrapInQuotes(_.trim(keyData.name));
+	if (_.isEmpty(keyData.columns)) {
+		return {
+			statement: '',
+			isActivated: false,
+		};
+	}
 	const isAllColumnsDeactivated = checkAllKeysDeactivated(keyData.columns || []);
+	const constraintName = wrapInQuotes(_.trim(keyData.name));
 	const columns = !_.isEmpty(keyData.columns)
 		? getColumnsList(keyData.columns, isAllColumnsDeactivated, isParentActivated)
 		: '';
@@ -149,10 +155,12 @@ const createInlineCheckConstraint = checkConstraint => {
 const alterKeyConstraint = (tableName, isParentActivated, keyData) => {
 	const constraintStatementDto = createKeyConstraint(templates, isParentActivated)(keyData);
 	return {
-		statement: assignTemplates(templates.addPkConstraint, {
-			constraintStatement: (constraintStatementDto.statement || '').trim(),
-			tableName,
-		}),
+		statement: constraintStatementDto.statement
+			? assignTemplates(templates.addPkConstraint, {
+					constraintStatement: constraintStatementDto.statement.trim(),
+					tableName,
+				})
+			: '',
 		isActivated: constraintStatementDto.isActivated,
 	};
 };

--- a/forward_engineering/ddlProvider/ddlHelpers/constraintsHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/constraintsHelper.js
@@ -75,8 +75,8 @@ const createKeyConstraint = (templates, isParentActivated) => keyData => {
 			isActivated: false,
 		};
 	}
-	const isAllColumnsDeactivated = checkAllKeysDeactivated(keyData.columns || []);
 	const constraintName = wrapInQuotes(_.trim(keyData.name));
+	const isAllColumnsDeactivated = checkAllKeysDeactivated(keyData.columns || []);
 	const columns = !_.isEmpty(keyData.columns)
 		? getColumnsList(keyData.columns, isAllColumnsDeactivated, isParentActivated)
 		: '';

--- a/forward_engineering/ddlProvider/ddlHelpers/constraintsHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/constraintsHelper.js
@@ -69,12 +69,6 @@ const foreignActiveKeysToString = keys => {
  * }}
  * */
 const createKeyConstraint = (templates, isParentActivated) => keyData => {
-	if (_.isEmpty(keyData.columns)) {
-		return {
-			statement: '',
-			isActivated: false,
-		};
-	}
 	const constraintName = wrapInQuotes(_.trim(keyData.name));
 	const isAllColumnsDeactivated = checkAllKeysDeactivated(keyData.columns || []);
 	const columns = !_.isEmpty(keyData.columns)
@@ -155,12 +149,10 @@ const createInlineCheckConstraint = checkConstraint => {
 const alterKeyConstraint = (tableName, isParentActivated, keyData) => {
 	const constraintStatementDto = createKeyConstraint(templates, isParentActivated)(keyData);
 	return {
-		statement: constraintStatementDto.statement
-			? assignTemplates(templates.addPkConstraint, {
-					constraintStatement: constraintStatementDto.statement.trim(),
-					tableName,
-				})
-			: '',
+		statement: assignTemplates(templates.addPkConstraint, {
+			constraintStatement: constraintStatementDto.statement.trim(),
+			tableName,
+		}),
 		isActivated: constraintStatementDto.isActivated,
 	};
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13030" title="HCK-13030" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13030</a>  [PostgreSQL]: Composite PKs are generated when they shouldn't
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Technical details

Do not generate a statement if no PK/UK columns.