### PR TITLE
HCK-13032: remove entity-level check statement without expression

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
@@ -68,7 +68,7 @@ const mapCheckConstraintNamesToChangeHistory = collection => {
  * */
 const getDropCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 	return constraintHistory
-		.filter(historyEntry => historyEntry.old && !historyEntry.new)
+		.filter(historyEntry => historyEntry.old?.constrExpression && !historyEntry.new?.constrExpression)
 		.map(historyEntry => {
 			const wrappedConstraintName = wrapInQuotes(historyEntry.old.chkConstrName);
 			return dropConstraint(fullTableName, wrappedConstraintName);
@@ -100,7 +100,12 @@ const addCheckConstraint = (tableName, constraintName, expression, noInherit = f
  * */
 const getAddCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 	return constraintHistory
-		.filter(historyEntry => historyEntry.new && !historyEntry.old)
+		.filter(
+			historyEntry =>
+				historyEntry.new?.chkConstrName &&
+				historyEntry.new?.constrExpression &&
+				!historyEntry.old?.constrExpression,
+		)
 		.map(historyEntry => {
 			const { chkConstrName, constrExpression, noInherit } = historyEntry.new;
 			return addCheckConstraint(fullTableName, wrapInQuotes(chkConstrName), constrExpression, noInherit);
@@ -116,7 +121,7 @@ const getAddCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 const getUpdateCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 	return constraintHistory
 		.filter(historyEntry => {
-			if (historyEntry.old && historyEntry.new) {
+			if (historyEntry.old?.constrExpression && historyEntry.new?.constrExpression) {
 				const oldExpression = historyEntry.old.constrExpression;
 				const newExpression = historyEntry.new.constrExpression;
 				const oldNoInherit = historyEntry.old.noInherit;

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
@@ -100,12 +100,7 @@ const addCheckConstraint = (tableName, constraintName, expression, noInherit = f
  * */
 const getAddCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 	return constraintHistory
-		.filter(
-			historyEntry =>
-				historyEntry.new?.chkConstrName &&
-				historyEntry.new?.constrExpression &&
-				!historyEntry.old?.constrExpression,
-		)
+		.filter(historyEntry => historyEntry.new?.constrExpression && !historyEntry.old?.constrExpression)
 		.map(historyEntry => {
 			const { chkConstrName, constrExpression, noInherit } = historyEntry.new;
 			return addCheckConstraint(fullTableName, wrapInQuotes(chkConstrName), constrExpression, noInherit);

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -290,11 +290,15 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		createCheckConstraint(checkConstraint) {
-			return assignTemplates(templates.checkConstraint, {
-				name: checkConstraint.name ? `CONSTRAINT ${wrapInQuotes(checkConstraint.name)}` : '',
-				expression: cleanCheckConstraint(checkConstraint.expression),
-				noInherit: checkConstraint.noInherit ? ' NO INHERIT' : '',
-			});
+			const expression = cleanCheckConstraint(checkConstraint.expression);
+			return (
+				expression &&
+				assignTemplates(templates.checkConstraint, {
+					name: checkConstraint.name ? `CONSTRAINT ${wrapInQuotes(checkConstraint.name)}` : '',
+					expression,
+					noInherit: checkConstraint.noInherit ? ' NO INHERIT' : '',
+				})
+			);
 		},
 
 		/**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13032" title="HCK-13032" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13032</a>  [PostgreSQL][DDL] Column-level check constraints are incorrectly visible in Script FE tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

We shouldn't generate entity-level check constraint statement without name or expression.