### PR TITLE
fix: lost bind context

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -200,13 +200,13 @@ const getAlterCollectionsScriptDtos = ({
 	);
 
 	return [
+		...createCollectionsScriptDtos,
 		...deleteCollectionScriptDtos,
 		...modifyCollectionScriptDtos,
 		...addColumnScriptDtos,
 		...deleteColumnScriptDtos,
 		...modifyColumnScriptDtos,
 		...modifyCollectionKeysScriptDtos,
-		...createCollectionsScriptDtos,
 	].filter(Boolean);
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -81,7 +81,7 @@ const getAddCollectionScriptDto =
 			});
 		const tableData = {
 			name: getEntityName(jsonSchema),
-			columns: columnDefinitions.map(ddlProvider.convertColumnDefinition),
+			columns: columnDefinitions.map(def => ddlProvider.convertColumnDefinition(def)),
 			checkConstraints: checkConstraints,
 			foreignKeyConstraints,
 			schemaData,

--- a/forward_engineering/alterScript/alterScriptHelpers/alterUdtHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterUdtHelper.js
@@ -100,7 +100,7 @@ const getAddColumnToTypeScriptDtos =
 					definitionJsonSchema,
 				});
 			})
-			.map(ddlProvider.convertColumnDefinition)
+			.map(def => ddlProvider.convertColumnDefinition(def))
 			.map(columnDefinition => ddlProvider.alterTypeAddAttribute(fullName, columnDefinition))
 			.map(script => AlterScriptDto.getInstance([script], udt.isActivated, false))
 			.filter(Boolean);


### PR DESCRIPTION
## Technical details

We call `this.createCheckConstraint` inside `convertColumnDefinition`. We need to ensure context is present. Lambda is used instead of `.bind()`

Also, rollback the position of the create statements to the previous