### PR TITLE
HCK-13527: improve type conversion from and to Polyglot

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -190,6 +190,77 @@
 					"length": 10485760
 				}
 			},
+			{
+				"from": {
+					"type": "varchar",
+					"format": "ipv4"
+				},
+				"to": {
+					"mode": "inet"
+				}
+			},
+			{
+				"from": {
+					"type": "nvarchar",
+					"format": "ipv4"
+				},
+				"to": {
+					"mode": "inet"
+				}
+			},
+			{
+				"from": {
+					"type": "time"
+				},
+				"to": {
+					"timePrecision": { "type": "Source", "path": "tPrecision" }
+				}
+			},
+			{
+				"from": {
+					"type": "timestamp_ntz"
+				},
+				"to": {
+					"timezone": "WITHOUT TIME ZONE",
+					"timePrecision": { "type": "Source", "path": "tPrecision" }
+				}
+			},
+			{
+				"from": {
+					"type": "timestamp_ltz"
+				},
+				"to": {
+					"timezone": "WITH TIME ZONE",
+					"timePrecision": { "type": "Source", "path": "tPrecision" }
+				}
+			},
+			{
+				"from": {
+					"type": "timestamp_tz"
+				},
+				"to": {
+					"timezone": "WITH TIME ZONE",
+					"timePrecision": { "type": "Source", "path": "tPrecision" }
+				}
+			},
+			{
+				"from": {
+					"type": "varchar",
+					"format": "duration"
+				},
+				"to": {
+					"mode": "interval"
+				}
+			},
+			{
+				"from": {
+					"type": "nvarchar",
+					"format": "duration"
+				},
+				"to": {
+					"mode": "interval"
+				}
+			},
 			[
 				"deconstructArrayIntoArrayType",
 				{

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -52,6 +52,42 @@
 			},
 			{
 				"from": {
+					"type": "inet"
+				},
+				"to": {
+					"format": "ipv4"
+				}
+			},
+			{
+				"from": {
+					"type": "datetime"
+				},
+				"to": {
+					"tPrecision": { "type": "Source", "path": "timePrecision" }
+				}
+			},
+			{
+				"from": {
+					"type": "datetime",
+					"mode": "timestamp",
+					"timezone": "WITH TIME ZONE"
+				},
+				"to": {
+					"mode": "timestamp with time zone"
+				}
+			},
+			{
+				"from": {
+					"type": "datetime",
+					"mode": "timestamp",
+					"timezone": "WITHOUT TIME ZONE"
+				},
+				"to": {
+					"mode": "timestamp without time zone"
+				}
+			},
+			{
+				"from": {
 					"mode": "varchar",
 					"length": 10485760
 				},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13527" title="HCK-13527" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13527</a>  [PostgreSQL]: fix the data types conversion by adapter
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

PostgreSQL → Polyglot

* `timestamp` with property timezone `WITH TIME ZONE` and precision should be converted to `timestamp_tz` with precision

* `timestamp` with property timezone `WITHOUT TIME ZONE` and precision should be converted to `timestamp_ntz` with precision

* `timestamp` with property timezone empty and precision should be converted to `timestamp_ntz` with precision and Synonym `timestamp`

* `time` with precision should be converted to `time` with precision

* `inet` should be converted to `varchar` with format `ipv4`

* `interval` should be converted to `varchar` with format `duration`

Polyglot → PostgreSQL

* `time` with precision should be converted to `time` with precision

* `timestamp_ntz` with precision should be converted to `timestamp` with property timezone `WITHOUT TIME ZONE` and precision

* `timestamp_ltz` with precision should be converted to `timestamp` with property timezone `WITH TIME ZONE` and precision

* `timestamp_tz` with precision should be converted to `timestamp` with property timezone `WITH TIME ZONE` and precision

* `varchar` or `nvarchar` with format `ipv4` or `ipv6` should be converted to `inet`

* `varchar` or `nvarchar` with duration should be converted to `interval`