### PR TITLE
HCK-13797: custom type names safe declaration

### DIFF
--- a/forward_engineering/ddlProvider/ddlHelpers/columnDefinitionHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/columnDefinitionHelper.js
@@ -63,18 +63,22 @@ const decorateType = (type, columnDefinition) => {
 	const { length, precision, scale, typeModifier, srid, timezone, timePrecision, dimension, subtype, array_type } =
 		columnDefinition;
 
+	const safeType = wrapInQuotes(type);
+
 	if (canHaveLength(type) && _.isNumber(length)) {
-		type = addLength(type, length);
+		type = addLength(safeType, length);
 	} else if (canHavePrecision(type) && canHaveScale(type) && _.isNumber(precision)) {
-		type = addScalePrecision(type, precision, scale);
+		type = addScalePrecision(safeType, precision, scale);
 	} else if (canHavePrecision(type) && _.isNumber(precision)) {
-		type = addPrecision(type, precision);
+		type = addPrecision(safeType, precision);
 	} else if (canHaveTypeModifier(type)) {
-		type = addTypeModifier({ type, typeModifier, srid });
+		type = addTypeModifier({ type: safeType, typeModifier, srid });
 	} else if (canHaveTimePrecision(type) && (_.isNumber(timePrecision) || timezone)) {
-		type = addWithTimezone(addPrecision(type, timePrecision), timezone);
+		type = addWithTimezone(addPrecision(safeType, timePrecision), timezone);
 	} else if (isVector(type)) {
 		type = dimension ? decorateVector(subtype, dimension) : subtype;
+	} else {
+		type = safeType;
 	}
 
 	return addArrayDecorator(type, array_type);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13797" title="HCK-13797" target="_blank"><img alt="Bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13797</a>  [PostgreSQL] FE: Cannot read properties of undefined (reading ‘map’)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

* this PR fixes an issue where user-defined PostgreSQL type names with special characters (like hyphens) were not quoted in column definitions.