### PR TITLE
HCK-14860: ALTER script with custom hooks

### DIFF
--- a/forward_engineering/alterScript/alterScriptBuilder.js
+++ b/forward_engineering/alterScript/alterScriptBuilder.js
@@ -3,36 +3,49 @@ const { AlterScriptDto } = require('./types/AlterScriptDto');
 const { commentIfDeactivated } = require('../utils/general');
 
 /**
+ * @param {AlterScriptDto} dtos
+ * @param {boolean} shouldApplyDropStatements
+ * @return {AlterScriptDto}
+ * */
+const commentDto = (dto, shouldApplyDropStatements) => {
+	let script = dto.script;
+	const shouldDeactivate = dto.isActivated === false || (!shouldApplyDropStatements && dto.isDropScript);
+	if (shouldDeactivate) {
+		script = commentIfDeactivated(script, {
+			isActivated: false,
+			isPartOfLine: false,
+		});
+	}
+	return { ...dto, script };
+};
+
+/**
+ * @param {AlterScriptDto[]} dtos
+ * @param {boolean} shouldApplyDropStatements
+ * @return {AlterScriptDto[]}
+ * */
+const commentDtosIfRequired = (dtos, shouldApplyDropStatements) => {
+	return dtos.reduce((finalDtos, dto) => {
+		if (!dto) {
+			return finalDtos;
+		}
+		return [...finalDtos, commentDto(dto, shouldApplyDropStatements)];
+	}, []);
+};
+
+/**
  * @param {AlterScriptDto[]} dtos
  * @param {boolean} shouldApplyDropStatements
  * @return {string}
  * */
 const joinAlterScriptDtosIntoScript = (dtos, shouldApplyDropStatements) => {
-	return dtos
-		.map(dto => {
-			if (dto.isActivated === false) {
-				return dto.scripts.map(scriptDto =>
-					commentIfDeactivated(scriptDto.script, {
-						isActivated: false,
-						isPartOfLine: false,
-					}),
-				);
-			}
-			if (!shouldApplyDropStatements) {
-				return dto.scripts.map(scriptDto =>
-					commentIfDeactivated(scriptDto.script, {
-						isActivated: !scriptDto.isDropScript,
-						isPartOfLine: false,
-					}),
-				);
-			}
-			return dto.scripts.map(scriptDto => scriptDto.script);
-		})
-		.flat()
-		.filter(Boolean)
-		.map(scriptLine => scriptLine.trim())
-		.filter(Boolean)
-		.join('\n\n');
+	return dtos.reduce((finalScript, dto) => {
+		if (!dto) {
+			return finalScript;
+		}
+		const { script } = commentDto(dto, shouldApplyDropStatements);
+		return `${finalScript}\n\n${script}`;
+	}, '');
 };
 
 /**
@@ -46,7 +59,9 @@ const buildEntityLevelAlterScript = (data, app) => {
 		option => option.id === 'applyDropStatements' && option.value,
 	);
 
-	return joinAlterScriptDtosIntoScript(alterScriptDtos, shouldApplyDropStatements);
+	return data.options?.keepDtos
+		? commentDtosIfRequired(alterScriptDtos, shouldApplyDropStatements)
+		: joinAlterScriptDtosIntoScript(alterScriptDtos, shouldApplyDropStatements);
 };
 
 /**
@@ -56,11 +71,7 @@ const buildEntityLevelAlterScript = (data, app) => {
  * */
 const doesEntityLevelAlterScriptContainDropStatements = (data, app) => {
 	const alterScriptDtos = getAlterScriptDtos(data, app);
-	return alterScriptDtos.some(
-		alterScriptDto =>
-			alterScriptDto.isActivated &&
-			alterScriptDto.scripts.some(scriptModificationDto => scriptModificationDto.isDropScript),
-	);
+	return alterScriptDtos.some(alterScriptDto => alterScriptDto?.isActivated && alterScriptDto.isDropScript);
 };
 
 const mapCoreDataForContainerLevelScripts = data => {
@@ -83,7 +94,9 @@ const buildContainerLevelAlterScript = (data, app) => {
 		option => option.id === 'applyDropStatements' && option.value,
 	);
 
-	return joinAlterScriptDtosIntoScript(alterScriptDtos, shouldApplyDropStatements);
+	return preparedData.options?.keepDtos
+		? commentDtosIfRequired(alterScriptDtos, shouldApplyDropStatements)
+		: joinAlterScriptDtosIntoScript(alterScriptDtos, shouldApplyDropStatements);
 };
 
 /**
@@ -94,11 +107,7 @@ const buildContainerLevelAlterScript = (data, app) => {
 const doesContainerLevelAlterScriptContainDropStatements = (data, app) => {
 	const preparedData = mapCoreDataForContainerLevelScripts(data);
 	const alterScriptDtos = getAlterScriptDtos(preparedData, app);
-	return alterScriptDtos.some(
-		alterScriptDto =>
-			alterScriptDto.isActivated &&
-			alterScriptDto.scripts.some(scriptModificationDto => scriptModificationDto.isDropScript),
-	);
+	return alterScriptDtos.some(alterScriptDto => alterScriptDto?.isActivated && alterScriptDto.isDropScript);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -5,7 +5,7 @@ const {
 	getModifyContainerScriptDtos,
 } = require('./alterScriptHelpers/alterContainerHelper');
 const {
-	getAddCollectionScriptDto,
+	getAddCollectionScriptDtos,
 	getDeleteCollectionScriptDto,
 	getAddColumnScriptDtos,
 	getDeleteColumnScriptDtos,
@@ -38,7 +38,6 @@ const {
 	getDeleteContainerSequencesScriptDtos,
 	getAddContainerSequencesScriptDtos,
 } = require('./alterScriptHelpers/containerHelpers/sequencesHelper');
-const { isObjectInDeltaModelActivated } = require('../utils/general');
 const { getModifiedCommentOnColumnScriptDtos } = require('./alterScriptHelpers/columnHelpers/commentsHelper');
 
 const getItems = data => [data?.items].flat().filter(Boolean);
@@ -58,14 +57,12 @@ const getAlterContainersScriptDtos = ({ collection }) => {
 
 	const addContainersScriptDtos = addedContainers.map(container => {
 		const [containerName, containerData] = Object.entries(container.properties)[0];
-		const isActivated = isObjectInDeltaModelActivated(containerData);
-		return getAddContainerScriptDto(containerName, isActivated);
+		return getAddContainerScriptDto(containerName, containerData);
 	});
 
 	const deleteContainersScriptDtos = deletedContainers.map(container => {
 		const [containerName, containerData] = Object.entries(container.properties)[0];
-		const isActivated = isObjectInDeltaModelActivated(containerData);
-		return getDeleteContainerScriptDto(containerName, isActivated);
+		return getDeleteContainerScriptDto(containerName, containerData);
 	});
 
 	const modifyContainersScriptDtos = modifiedContainers
@@ -154,8 +151,8 @@ const getAlterCollectionsScriptDtos = ({
 	const createCollectionsScriptDtos = sortCollectionsByRelationships(
 		createScriptsData.filter(collection => collection.compMod?.created),
 		inlineDeltaRelationships,
-	).map(
-		getAddCollectionScriptDto({
+	).flatMap(
+		getAddCollectionScriptDtos({
 			app,
 			dbVersion,
 			modelDefinitions,
@@ -322,32 +319,6 @@ const getAlterRelationshipsScriptDtos = ({ collection, app, ignoreRelationshipID
 };
 
 /**
- * @param dto {AlterScriptDto}
- * @return {AlterScriptDto | undefined}
- */
-const prettifyAlterScriptDto = dto => {
-	if (!dto) {
-		return undefined;
-	}
-	/**
-	 * @type {Array<ModificationScript>}
-	 * */
-	const nonEmptyScriptModificationDtos = dto.scripts
-		.map(scriptDto => ({
-			...scriptDto,
-			script: (scriptDto.script || '').trim(),
-		}))
-		.filter(scriptDto => Boolean(scriptDto.script));
-	if (!nonEmptyScriptModificationDtos.length) {
-		return undefined;
-	}
-	return {
-		...dto,
-		scripts: nonEmptyScriptModificationDtos,
-	};
-};
-
-/**
  * @param {{
  * collection: Object,
  * app: App,
@@ -444,10 +415,7 @@ const getAlterScriptDtos = (data, app) => {
 		...containersSequencesScriptDtos,
 		...viewScriptDtos,
 		...relationshipScriptDtos,
-	]
-		.filter(Boolean)
-		.map(dto => prettifyAlterScriptDto(dto))
-		.filter(Boolean);
+	].filter(Boolean);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterContainerHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterContainerHelper.js
@@ -1,9 +1,10 @@
 const _ = require('lodash');
 const { getModifySchemaCommentsScriptDtos } = require('./containerHelpers/commentsHelper');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 const assignTemplates = require('../../utils/assignTemplates');
 const templates = require('../../ddlProvider/templates');
-const { wrapInQuotes } = require('../../utils/general');
+const { wrapInQuotes, getId } = require('../../utils/general');
+const { isObjectInDeltaModelActivated } = require('../../utils/general');
 
 /**
  * @param {string} schemaName
@@ -32,9 +33,10 @@ const dropSchema = schemaName => {
  * @param {boolean} isActivated
  * @return {AlterScriptDto | undefined}
  * */
-const getAddContainerScriptDto = (containerName, isActivated = true) => {
+const getAddContainerScriptDto = (containerName, jsonSchema) => {
+	const isActivated = isObjectInDeltaModelActivated(jsonSchema) ?? true;
 	const script = createSchemaOnly(wrapInQuotes(containerName));
-	return AlterScriptDto.getInstance([script], isActivated, false);
+	return AlterScriptDto.getInstance(script, isActivated, false, SCRIPT_TYPE.createContainer, getId(jsonSchema));
 };
 
 /**
@@ -42,9 +44,10 @@ const getAddContainerScriptDto = (containerName, isActivated = true) => {
  * @param {boolean} isActivated
  * @return {AlterScriptDto | undefined}
  * */
-const getDeleteContainerScriptDto = (containerName, isActivated = true) => {
+const getDeleteContainerScriptDto = (containerName, jsonSchema) => {
+	const isActivated = isObjectInDeltaModelActivated(jsonSchema) ?? true;
 	const script = dropSchema(wrapInQuotes(containerName));
-	return AlterScriptDto.getInstance([script], isActivated, true);
+	return AlterScriptDto.getInstance(script, isActivated, true, SCRIPT_TYPE.dropContainer, getId(jsonSchema));
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -6,7 +6,7 @@ const { getModifyNonNullColumnsScriptDtos } = require('./columnHelpers/nonNullCo
 const { getModifiedCommentOnColumnScriptDtos } = require('./columnHelpers/commentsHelper');
 const { getRenameColumnScriptDtos } = require('./columnHelpers/renameColumnHelper');
 const { getModifyColumnCheckConstraintScriptDtos } = require('./columnHelpers/checkConstraintHelper');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 const { AlterCollectionDto } = require('../types/AlterCollectionDto');
 const { getModifyPkConstraintsScriptDtos } = require('./entityHelpers/primaryKeyHelper');
 const { getModifyUniqueKeyConstraintsScriptDtos } = require('./entityHelpers/uniqueKeyHelper');
@@ -23,13 +23,14 @@ const {
 	wrapInQuotes,
 	isParentContainerActivated,
 	isObjectInDeltaModelActivated,
+	getId,
 } = require('../../utils/general');
 const { getRelationshipName } = require('./alterRelationshipsHelper');
 
 /**
  * @return {(collection: AlterCollectionDto) => AlterScriptDto | undefined}
  * */
-const getAddCollectionScriptDto =
+const getAddCollectionScriptDtos =
 	({ app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions, inlineDeltaRelationships = [] }) =>
 	collection => {
 		const ddlProvider = require('../../ddlProvider/ddlProvider')(null, null, app);
@@ -94,9 +95,12 @@ const getAddCollectionScriptDto =
 			ddlProvider,
 			collection,
 			dbVersion,
-		}).flatMap(({ scripts }) => scripts.map(({ script }) => script));
+		});
 		const script = ddlProvider.createTable(hydratedTable, jsonSchema.isActivated);
-		return AlterScriptDto.getInstance([script, ...indexesOnNewlyCreatedColumnsScripts], true, false);
+		return [
+			AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.createEntity, getId(jsonSchema)),
+			...indexesOnNewlyCreatedColumnsScripts,
+		];
 	};
 
 /**
@@ -106,7 +110,7 @@ const getDeleteCollectionScriptDto = app => collection => {
 	const ddlProvider = require('../../ddlProvider/ddlProvider')(null, null, app);
 	const fullName = getFullTableName(collection);
 	const script = ddlProvider.dropTable(fullName);
-	return AlterScriptDto.getInstance([script], true, true);
+	return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.dropEntity, getId(collection));
 };
 
 /**
@@ -175,15 +179,19 @@ const getAddColumnsByConditionScriptDtos =
 					definitionJsonSchema,
 				});
 				const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-				return { columnDefinition, isActivated };
-			})
-			.map(({ columnDefinition, isActivated }) => ({
-				script: ddlProvider.addColumn(fullName, ddlProvider.convertColumnDefinition(columnDefinition)),
-				isActivated,
-			}))
-			.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, false));
 
-		return scripts.filter(Boolean);
+				const script = ddlProvider.addColumn(fullName, ddlProvider.convertColumnDefinition(columnDefinition));
+				return AlterScriptDto.getInstance(
+					script,
+					isActivated,
+					false,
+					SCRIPT_TYPE.alterEntity,
+					getId(collectionSchema),
+				);
+			})
+			.filter(Boolean);
+
+		return scripts;
 	};
 
 /**
@@ -248,9 +256,15 @@ const getDeleteColumnsByConditionScriptDtos = app => (collection, predicate) => 
 		.map(([name, jsonSchema]) => {
 			const columnNameForDDL = wrapInQuotes(name);
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: ddlProvider.dropColumn(fullTableName, columnNameForDDL), isActivated };
+			const script = ddlProvider.dropColumn(fullTableName, columnNameForDDL);
+			return AlterScriptDto.getInstance(
+				script,
+				isActivated,
+				true,
+				SCRIPT_TYPE.alterEntity,
+				getId(collectionSchema),
+			);
 		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, true))
 		.filter(Boolean);
 };
 
@@ -338,7 +352,7 @@ const getModifyColumnScriptDtos =
 	};
 
 module.exports = {
-	getAddCollectionScriptDto,
+	getAddCollectionScriptDtos,
 	getDeleteCollectionScriptDto,
 	getModifyCollectionScriptDtos,
 	getAddColumnScriptDtos,

--- a/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
@@ -1,5 +1,4 @@
-const _ = require('lodash');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 const { AlterRelationshipDto } = require('../types/AlterRelationshipDto');
 const { getNamePrefixedWithSchemaName, wrapInQuotes } = require('../../utils/general');
 
@@ -66,7 +65,7 @@ const canRelationshipBeAdded = relationship => {
 		compMod.child?.bucket,
 		compMod.child?.collection,
 		compMod.child?.collection?.fkFields?.length,
-	].every(property => Boolean(property));
+	].every(Boolean);
 };
 
 /**
@@ -77,10 +76,14 @@ const getAddForeignKeyScriptDtos = ddlProvider => addedRelationships => {
 		.filter(relationship => canRelationshipBeAdded(relationship))
 		.map(relationship => {
 			const scriptDto = getAddSingleForeignKeyStatementDto(ddlProvider)(relationship);
-			return AlterScriptDto.getInstance([scriptDto.statement], scriptDto.isActivated, false);
+			return AlterScriptDto.getInstance(
+				scriptDto.statement,
+				scriptDto.isActivated,
+				false,
+				SCRIPT_TYPE.alterEntity,
+			);
 		})
-		.filter(Boolean)
-		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+		.filter(Boolean);
 };
 
 /**
@@ -119,7 +122,7 @@ const canRelationshipBeDeleted = relationship => {
 		compMod.code?.old || compMod.name?.old || getRelationshipName(relationship),
 		compMod.child?.bucket,
 		compMod.child?.collection,
-	].every(property => Boolean(property));
+	].every(Boolean);
 };
 
 /**
@@ -130,10 +133,14 @@ const getDeleteForeignKeyScriptDtos = ddlProvider => deletedRelationships => {
 		.filter(relationship => canRelationshipBeDeleted(relationship))
 		.map(relationship => {
 			const scriptDto = getDeleteSingleForeignKeyStatementDto(ddlProvider)(relationship);
-			return AlterScriptDto.getInstance([scriptDto.statement], scriptDto.isActivated, true);
+			return AlterScriptDto.getInstance(
+				scriptDto.statement,
+				scriptDto.isActivated,
+				true,
+				SCRIPT_TYPE.alterEntity,
+			);
 		})
-		.filter(Boolean)
-		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+		.filter(Boolean);
 };
 
 /**
@@ -142,18 +149,16 @@ const getDeleteForeignKeyScriptDtos = ddlProvider => deletedRelationships => {
 const getModifyForeignKeyScriptDtos = ddlProvider => modifiedRelationships => {
 	return modifiedRelationships
 		.filter(relationship => canRelationshipBeAdded(relationship) && canRelationshipBeDeleted(relationship))
-		.map(relationship => {
+		.flatMap(relationship => {
 			const deleteScriptDto = getDeleteSingleForeignKeyStatementDto(ddlProvider)(relationship);
 			const addScriptDto = getAddSingleForeignKeyStatementDto(ddlProvider)(relationship);
 			const isActivated = addScriptDto.isActivated && deleteScriptDto.isActivated;
-			return AlterScriptDto.getDropAndRecreateInstance(
-				deleteScriptDto.statement,
-				addScriptDto.statement,
-				isActivated,
-			);
+			return [
+				AlterScriptDto.getInstance(deleteScriptDto.statement, isActivated, true, SCRIPT_TYPE.alterEntity),
+				AlterScriptDto.getInstance(addScriptDto.statement, isActivated, false, SCRIPT_TYPE.alterEntity),
+			];
 		})
-		.filter(Boolean)
-		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+		.filter(Boolean);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterUdtHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterUdtHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 const {
 	getUdtName,
 	wrapInQuotes,
@@ -49,7 +49,7 @@ const getCreateUdtScriptDto =
 		const udt = { ...updatedUdt, properties: columnDefinitions };
 
 		const script = ddlProvider.createUdt(udt);
-		return AlterScriptDto.getInstance([script], jsonSchema.isActivated, false);
+		return AlterScriptDto.getInstance(script, jsonSchema.isActivated, false, SCRIPT_TYPE.createUDT);
 	};
 
 /**
@@ -61,10 +61,10 @@ const getDeleteUdtScriptDto = app => udt => {
 	const ddlUdtName = wrapInQuotes(getUdtName(udt));
 	if (udt.type === 'domain') {
 		const script = ddlProvider.dropDomain(ddlUdtName);
-		return AlterScriptDto.getInstance([script], udt.isActivated, true);
+		return AlterScriptDto.getInstance(script, udt.isActivated, true, SCRIPT_TYPE.dropUDT);
 	} else {
 		const script = ddlProvider.dropType(ddlUdtName);
-		return AlterScriptDto.getInstance([script], udt.isActivated, true);
+		return AlterScriptDto.getInstance(script, udt.isActivated, true, SCRIPT_TYPE.dropUDT);
 	}
 };
 
@@ -91,7 +91,7 @@ const getAddColumnToTypeScriptDtos =
 					externalDefinitions,
 				});
 
-				return createColumnDefinitionBySchema({
+				const def = createColumnDefinitionBySchema({
 					name,
 					jsonSchema,
 					parentJsonSchema: { required: [] },
@@ -99,10 +99,10 @@ const getAddColumnToTypeScriptDtos =
 					schemaData,
 					definitionJsonSchema,
 				});
+				const columnDefinition = ddlProvider.convertColumnDefinition(def);
+				const script = ddlProvider.alterTypeAddAttribute(fullName, columnDefinition);
+				return AlterScriptDto.getInstance(script, udt.isActivated, false, SCRIPT_TYPE.alterUDT);
 			})
-			.map(def => ddlProvider.convertColumnDefinition(def))
-			.map(columnDefinition => ddlProvider.alterTypeAddAttribute(fullName, columnDefinition))
-			.map(script => AlterScriptDto.getInstance([script], udt.isActivated, false))
 			.filter(Boolean);
 	};
 
@@ -117,8 +117,10 @@ const getDeleteColumnFromTypeScriptDtos = app => udt => {
 
 	return _.toPairs(udt.properties)
 		.filter(([name, jsonSchema]) => !jsonSchema.compMod)
-		.map(([name]) => ddlProvider.alterTypeDropAttribute(fullName, wrapInQuotes(name)))
-		.map(script => AlterScriptDto.getInstance([script], isActivated, true))
+		.map(([name]) => {
+			const script = ddlProvider.alterTypeDropAttribute(fullName, wrapInQuotes(name));
+			return AlterScriptDto.getInstance(script, isActivated, true, SCRIPT_TYPE.alterUDT);
+		})
 		.filter(Boolean);
 };
 
@@ -136,18 +138,18 @@ const getModifyColumnOfTypeScriptDtos = app => udt => {
 		.map(jsonSchema => {
 			const oldAttributeDDLName = wrapInQuotes(jsonSchema.compMod.oldField.name);
 			const newAttributeDDLName = wrapInQuotes(jsonSchema.compMod.newField.name);
-			return ddlProvider.alterTypeRenameAttribute(fullName, oldAttributeDDLName, newAttributeDDLName);
-		})
-		.map(script => AlterScriptDto.getInstance([script], isActivated, false));
+			const script = ddlProvider.alterTypeRenameAttribute(fullName, oldAttributeDDLName, newAttributeDDLName);
+			return AlterScriptDto.getInstance(script, isActivated, false, SCRIPT_TYPE.alterUDT);
+		});
 
 	const changeTypeScripts = _.toPairs(udt.properties)
 		.filter(([name, jsonSchema]) => checkFieldPropertiesChanged(jsonSchema.compMod, ['type', 'mode']))
 		.map(([name, jsonSchema]) => {
 			const attributeDDLName = wrapInQuotes(name);
 			const newDataType = jsonSchema.compMod.newField.mode || jsonSchema.compMod.newField.type;
-			return ddlProvider.alterTypeChangeAttributeType(fullName, attributeDDLName, newDataType);
-		})
-		.map(script => AlterScriptDto.getInstance([script], isActivated, false));
+			const script = ddlProvider.alterTypeChangeAttributeType(fullName, attributeDDLName, newDataType);
+			return AlterScriptDto.getInstance(script, isActivated, false, SCRIPT_TYPE.alterUDT);
+		});
 
 	return [...renameColumnScripts, ...changeTypeScripts].filter(Boolean);
 };

--- a/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const { getModifyViewCommentsScriptDtos } = require('./viewHelpers/commentsHelper');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
-const { wrapInQuotes } = require('../../utils/general');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
+const { wrapInQuotes, getId } = require('../../utils/general');
 
 const getKeys = ({ view, collectionRefsDefinitionsMap, ddlProvider, app }) => {
 	const { mapProperties } = app.require('@hackolade/ddl-fe-utils');
@@ -61,7 +61,7 @@ const getAddViewScriptDto = app => view => {
 	const hydratedView = ddlProvider.hydrateView({ viewData, entityData: [view] });
 
 	const script = ddlProvider.createView(hydratedView, {}, view.isActivated);
-	return AlterScriptDto.getInstance([script], true, false);
+	return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.createView, getId(view));
 };
 
 /**
@@ -72,7 +72,7 @@ const getDeleteViewScriptDto = app => view => {
 	const viewName = wrapInQuotes(view.code || view.name);
 
 	const script = ddlProvider.dropView(viewName);
-	return AlterScriptDto.getInstance([script], true, true);
+	return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.dropView, getId(view));
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/alterTypeHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/alterTypeHelper.js
@@ -1,11 +1,12 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	checkFieldPropertiesChanged,
 	getFullTableName,
 	wrapInQuotes,
 	isObjectInDeltaModelActivated,
 	isParentContainerActivated,
+	getId,
 } = require('../../../utils/general');
 const assignTemplates = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -88,9 +89,9 @@ const getUpdateTypesScriptDtos = collection => {
 			const columnName = wrapInQuotes(name);
 			const typeConfig = _.pick(jsonSchema, ['length', 'precision', 'scale']);
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: alterColumnType(fullTableName, columnName, typeName, typeConfig), isActivated };
-		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, false));
+			const script = alterColumnType(fullTableName, columnName, typeName, typeConfig);
+			return AlterScriptDto.getInstance(script, isActivated, false, SCRIPT_TYPE.alterEntity, getId(collection));
+		});
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/checkConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/checkConstraintHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	getFullTableName,
 	wrapInQuotes,
@@ -74,14 +74,14 @@ const mapColumnCheckConstraintsToChangeHistory = collection => {
 
 	_.toPairs(collection.properties).forEach(([columnName, jsonSchema]) => {
 		const oldColumnName = jsonSchema.compMod?.oldField?.name || columnName;
-		const newCheckConstraint = !_.isEmpty(jsonSchema.checkConstraint)
-			? _.omit(_.first(jsonSchema.checkConstraint), 'id')
-			: undefined;
+		const newCheckConstraint = _.isEmpty(jsonSchema.checkConstraint)
+			? undefined
+			: _.omit(_.first(jsonSchema.checkConstraint), 'id');
 
 		const oldCheckConstraintValue = collection.role.properties?.[oldColumnName]?.checkConstraint;
-		const oldCheckConstraint = !_.isEmpty(oldCheckConstraintValue)
-			? _.omit(_.first(oldCheckConstraintValue), 'id')
-			: undefined;
+		const oldCheckConstraint = _.isEmpty(oldCheckConstraintValue)
+			? undefined
+			: _.omit(_.first(oldCheckConstraintValue), 'id');
 
 		if (!newCheckConstraint && !oldCheckConstraint) {
 			return;
@@ -113,7 +113,7 @@ const getDropColumnCheckConstraintScriptDtos = (constraintHistory, fullTableName
 				fullTableName,
 			);
 			const script = dropConstraint(fullTableName, wrappedConstraintName);
-			return AlterScriptDto.getInstance([script], historyEntry.isActivated, true);
+			return AlterScriptDto.getInstance(script, historyEntry.isActivated, true, SCRIPT_TYPE.alterEntity);
 		});
 };
 
@@ -130,7 +130,7 @@ const getAddColumnCheckConstraintScriptDtos = (constraintHistory, fullTableName)
 			const constraintName = getConstraintName(name, historyEntry.columnName, fullTableName);
 
 			const script = addCheckConstraint(fullTableName, constraintName, expression, noInherit);
-			return AlterScriptDto.getInstance([script], historyEntry.isActivated);
+			return AlterScriptDto.getInstance(script, historyEntry.isActivated, false, SCRIPT_TYPE.alterEntity);
 		});
 };
 
@@ -153,7 +153,7 @@ const getUpdateColumnCheckConstraintScriptDtos = (constraintHistory, fullTableNa
 			}
 			return false;
 		})
-		.map(historyEntry => {
+		.flatMap(historyEntry => {
 			const { name: oldConstrainName } = historyEntry.old;
 			const wrappedOldConstraintName = getConstraintName(
 				oldConstrainName,
@@ -175,11 +175,20 @@ const getUpdateColumnCheckConstraintScriptDtos = (constraintHistory, fullTableNa
 			);
 
 			return [
-				AlterScriptDto.getInstance([dropConstraintScript], historyEntry.isActivated, true),
-				AlterScriptDto.getInstance([addConstraintScript], historyEntry.isActivated, false),
+				AlterScriptDto.getInstance(
+					dropConstraintScript,
+					historyEntry.isActivated,
+					true,
+					SCRIPT_TYPE.alterEntity,
+				),
+				AlterScriptDto.getInstance(
+					addConstraintScript,
+					historyEntry.isActivated,
+					false,
+					SCRIPT_TYPE.alterEntity,
+				),
 			];
-		})
-		.flat();
+		});
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/commentsHelper.js
@@ -1,10 +1,11 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	getFullColumnName,
 	wrapComment,
 	isObjectInDeltaModelActivated,
 	isParentContainerActivated,
+	getId,
 } = require('../../../utils/general');
 const assignTemplates = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -41,9 +42,9 @@ const getUpdatedCommentOnColumnScriptDtos = collection => {
 			const ddlComment = wrapComment(newComment);
 			const columnName = getFullColumnName(collection, name);
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: updateColumnComment(columnName, ddlComment), isActivated };
-		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, false));
+			const script = updateColumnComment(columnName, ddlComment);
+			return AlterScriptDto.getInstance(script, isActivated, false, SCRIPT_TYPE.alterEntity, getId(collection));
+		});
 };
 
 /**
@@ -75,9 +76,9 @@ const getDeletedCommentOnColumnScriptDtos = collection => {
 		.map(([name, jsonSchema]) => {
 			const columnName = getFullColumnName(collection, name);
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: dropColumnComment(columnName), isActivated };
-		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, true));
+			const script = dropColumnComment(columnName);
+			return AlterScriptDto.getInstance(script, isActivated, true, SCRIPT_TYPE.alterEntity, getId(collection));
+		});
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/defaultValueHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/defaultValueHelper.js
@@ -1,10 +1,11 @@
 const { toPairs } = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	getFullTableName,
 	wrapInQuotes,
 	isObjectInDeltaModelActivated,
 	isParentContainerActivated,
+	getId,
 } = require('../../../utils/general');
 const { decorateDefault } = require('../../../ddlProvider/ddlHelpers/columnDefinitionHelper');
 const assignTemplates = require('../../../utils/assignTemplates');
@@ -52,9 +53,9 @@ const getUpdatedDefaultColumnValueScriptDtos = ({ collection }) => {
 				defaultValue: decorateDefault(type, newDefaultValue, isArrayType),
 			};
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: updateColumnDefaultValue(scriptGenerationConfig), isActivated };
+			const script = updateColumnDefaultValue(scriptGenerationConfig);
+			return AlterScriptDto.getInstance(script, isActivated, false, SCRIPT_TYPE.alterEntity, getId(collection));
 		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, false))
 		.filter(Boolean);
 };
 
@@ -96,9 +97,9 @@ const getDeletedDefaultColumnValueScriptDtos = ({ collection }) => {
 				columnName: wrapInQuotes(columnName),
 			};
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: dropColumnDefaultValue(scriptGenerationConfig), isActivated };
+			const script = dropColumnDefaultValue(scriptGenerationConfig);
+			return AlterScriptDto.getInstance(script, isActivated, true, SCRIPT_TYPE.alterEntity, getId(collection));
 		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, true))
 		.filter(Boolean);
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nonNullConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nonNullConstraintHelper.js
@@ -1,10 +1,11 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	getFullTableName,
 	wrapInQuotes,
 	isObjectInDeltaModelActivated,
 	isParentContainerActivated,
+	getId,
 } = require('../../../utils/general');
 const assignTemplates = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -58,9 +59,9 @@ const getModifyNonNullColumnsScriptDtos = collection => {
 		})
 		.map(([columnName, jsonSchema]) => {
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: setNotNullConstraint(fullTableName, wrapInQuotes(columnName)), isActivated };
-		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, false));
+			const script = setNotNullConstraint(fullTableName, wrapInQuotes(columnName));
+			return AlterScriptDto.getInstance(script, isActivated, false, SCRIPT_TYPE.alterEntity, getId(collection));
+		});
 
 	const removeNotNullConstraint = _.toPairs(collection.properties)
 		.filter(([name, jsonSchema]) => {
@@ -71,9 +72,9 @@ const getModifyNonNullColumnsScriptDtos = collection => {
 		})
 		.map(([name, jsonSchema]) => {
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: dropNotNullConstraint(fullTableName, wrapInQuotes(name)), isActivated };
-		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, true));
+			const script = dropNotNullConstraint(fullTableName, wrapInQuotes(name));
+			return AlterScriptDto.getInstance(script, isActivated, true, SCRIPT_TYPE.alterEntity, getId(collection));
+		});
 
 	return [...addNotNullConstraintsScript, ...removeNotNullConstraint];
 };

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/renameColumnHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/renameColumnHelper.js
@@ -1,11 +1,12 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	checkFieldPropertiesChanged,
 	getFullTableName,
 	wrapInQuotes,
 	isParentContainerActivated,
 	isObjectInDeltaModelActivated,
+	getId,
 } = require('../../../utils/general');
 const assignTemplates = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -40,9 +41,9 @@ const getRenameColumnScriptDtos = collection => {
 			const oldColumnName = wrapInQuotes(jsonSchema.compMod.oldField.name);
 			const newColumnName = wrapInQuotes(jsonSchema.compMod.newField.name);
 			const isActivated = isContainerActivated && isCollectionActivated && jsonSchema.isActivated;
-			return { script: renameColumn(fullTableName, oldColumnName, newColumnName), isActivated };
-		})
-		.map(({ script, isActivated }) => AlterScriptDto.getInstance([script], isActivated, false));
+			const script = renameColumn(fullTableName, oldColumnName, newColumnName);
+			return AlterScriptDto.getInstance(script, isActivated, false, SCRIPT_TYPE.alterEntity, getId(collection));
+		});
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/commentsHelper.js
@@ -1,5 +1,5 @@
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
-const { wrapComment, wrapInQuotes, isObjectInDeltaModelActivated } = require('../../../utils/general');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
+const { wrapComment, wrapInQuotes, isObjectInDeltaModelActivated, getId } = require('../../../utils/general');
 const assignTemplates = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
 
@@ -31,7 +31,13 @@ const getUpsertCommentsScriptDto = container => {
 		const wrappedSchemaName = wrapInQuotes(container.role.name);
 		const script = updateSchemaComment(wrappedSchemaName, wrappedComment);
 		const isContainerActivated = isObjectInDeltaModelActivated(container);
-		return AlterScriptDto.getInstance([script], isContainerActivated, false);
+		return AlterScriptDto.getInstance(
+			script,
+			isContainerActivated,
+			false,
+			SCRIPT_TYPE.alterContainer,
+			getId(container),
+		);
 	}
 	return undefined;
 };
@@ -58,7 +64,13 @@ const getDropCommentsScriptDto = container => {
 		const wrappedSchemaName = wrapInQuotes(container.role.name);
 		const script = dropSchemaComment(wrappedSchemaName);
 		const isContainerActivated = isObjectInDeltaModelActivated(container);
-		return AlterScriptDto.getInstance([script], isContainerActivated, true);
+		return AlterScriptDto.getInstance(
+			script,
+			isContainerActivated,
+			true,
+			SCRIPT_TYPE.alterContainer,
+			getId(container),
+		);
 	}
 	return undefined;
 };

--- a/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/sequencesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/sequencesHelper.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { App } = require('../../../types/coreApplicationTypes');
-const { getDbName, getGroupItemsByCompMode, isObjectInDeltaModelActivated } = require('../../../utils/general');
+const { getDbName, getGroupItemsByCompMode, isObjectInDeltaModelActivated, getId } = require('../../../utils/general');
 const {
 	createSequenceScript,
 	dropSequenceScript,
@@ -20,8 +20,16 @@ const getAddContainerSequencesScriptDtos = ({ container }) => {
 	const isContainerActivated = isObjectInDeltaModelActivated(container);
 
 	return (container.role?.sequences || [])
-		.map(sequence => createSequenceScript({ schemaName, sequence }))
-		.map(script => AlterScriptDto.getInstance([script], isContainerActivated, false))
+		.map(sequence => {
+			const script = createSequenceScript({ schemaName, sequence });
+			return AlterScriptDto.getInstance(
+				script,
+				isContainerActivated,
+				false,
+				SCRIPT_TYPE.alterContainer,
+				getId(container),
+			);
+		})
 		.filter(Boolean);
 };
 
@@ -41,23 +49,43 @@ const getModifyContainerSequencesScriptDtos = ({ container }) => {
 		oldItems,
 	});
 
-	const removedScriptDtos = removed
-		.map(sequence => dropSequenceScript({ schemaName, sequence }))
-		.map(script => AlterScriptDto.getInstance([script], isContainerActivated, true));
-	const addedScriptDtos = added
-		.map(sequence => createSequenceScript({ schemaName, sequence }))
-		.map(script => AlterScriptDto.getInstance([script], isContainerActivated, false));
+	const removedScriptDtos = removed.map(sequence => {
+		const script = dropSequenceScript({ schemaName, sequence });
+		return AlterScriptDto.getInstance(
+			script,
+			isContainerActivated,
+			true,
+			SCRIPT_TYPE.alterContainer,
+			getId(container),
+		);
+	});
 
-	const modifiedScriptDtos = modified
-		.map(sequence => {
-			const oldSequence = _.find(oldItems, { id: sequence.id }) || {};
-			return alterSequenceScript({
-				schemaName,
-				sequence,
-				oldSequence,
-			});
-		})
-		.map(script => AlterScriptDto.getInstance([script], isContainerActivated, false));
+	const addedScriptDtos = added.map(sequence => {
+		const script = createSequenceScript({ schemaName, sequence });
+		return AlterScriptDto.getInstance(
+			script,
+			isContainerActivated,
+			false,
+			SCRIPT_TYPE.alterContainer,
+			getId(container),
+		);
+	});
+
+	const modifiedScriptDtos = modified.map(sequence => {
+		const oldSequence = _.find(oldItems, { id: sequence.id }) || {};
+		const script = alterSequenceScript({
+			schemaName,
+			sequence,
+			oldSequence,
+		});
+		return AlterScriptDto.getInstance(
+			script,
+			isContainerActivated,
+			false,
+			SCRIPT_TYPE.alterContainer,
+			getId(container),
+		);
+	});
 
 	return [...modifiedScriptDtos, ...removedScriptDtos, ...addedScriptDtos].filter(Boolean);
 };
@@ -72,8 +100,16 @@ const getDeleteContainerSequencesScriptDtos = ({ container }) => {
 	const isContainerActivated = isObjectInDeltaModelActivated(container);
 
 	return (container.role?.sequences || [])
-		.map(sequence => dropSequenceScript({ schemaName, sequence }))
-		.map(script => AlterScriptDto.getInstance([script], isContainerActivated, true))
+		.map(sequence => {
+			const script = dropSequenceScript({ schemaName, sequence });
+			return AlterScriptDto.getInstance(
+				script,
+				isContainerActivated,
+				true,
+				SCRIPT_TYPE.alterContainer,
+				getId(container),
+			);
+		})
 		.filter(Boolean);
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	getFullTableName,
 	wrapInQuotes,
@@ -71,9 +71,9 @@ const getDropCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 		.filter(historyEntry => historyEntry.old?.constrExpression && !historyEntry.new?.constrExpression)
 		.map(historyEntry => {
 			const wrappedConstraintName = wrapInQuotes(historyEntry.old.chkConstrName);
-			return dropConstraint(fullTableName, wrappedConstraintName);
-		})
-		.map(script => AlterScriptDto.getInstance([script], true, true));
+			const script = dropConstraint(fullTableName, wrappedConstraintName);
+			return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.alterEntity);
+		});
 };
 
 /**
@@ -103,9 +103,9 @@ const getAddCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 		.filter(historyEntry => historyEntry.new?.constrExpression && !historyEntry.old?.constrExpression)
 		.map(historyEntry => {
 			const { chkConstrName, constrExpression, noInherit } = historyEntry.new;
-			return addCheckConstraint(fullTableName, wrapInQuotes(chkConstrName), constrExpression, noInherit);
-		})
-		.map(script => AlterScriptDto.getInstance([script], true, false));
+			const script = addCheckConstraint(fullTableName, wrapInQuotes(chkConstrName), constrExpression, noInherit);
+			return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterEntity);
+		});
 };
 
 /**
@@ -125,7 +125,7 @@ const getUpdateCheckConstraintScriptDtos = (constraintHistory, fullTableName) =>
 			}
 			return false;
 		})
-		.map(historyEntry => {
+		.flatMap(historyEntry => {
 			const { chkConstrName: oldConstrainName } = historyEntry.old;
 			const dropConstraintScript = dropConstraint(fullTableName, wrapInQuotes(oldConstrainName));
 
@@ -142,11 +142,10 @@ const getUpdateCheckConstraintScriptDtos = (constraintHistory, fullTableName) =>
 			);
 
 			return [
-				AlterScriptDto.getInstance([dropConstraintScript], true, true),
-				AlterScriptDto.getInstance([addConstraintScript], true, false),
+				AlterScriptDto.getInstance(dropConstraintScript, true, true, SCRIPT_TYPE.alterEntity),
+				AlterScriptDto.getInstance(addConstraintScript, true, false, SCRIPT_TYPE.alterEntity),
 			];
-		})
-		.flat();
+		});
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/commentsHelper.js
@@ -1,11 +1,12 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const {
 	getFullTableName,
 	wrapComment,
 	isObjectInDeltaModelActivated,
 	isParentContainerActivated,
+	getId,
 } = require('../../../utils/general');
 const assignTemplates = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -45,7 +46,7 @@ const getUpdatedCommentOnCollectionScriptDto = collection => {
 	const isCollectionActivated = isContainerActivated && isObjectInDeltaModelActivated(collection);
 
 	const script = updateTableComment(tableName, comment);
-	return AlterScriptDto.getInstance([script], isCollectionActivated, false);
+	return AlterScriptDto.getInstance(script, isCollectionActivated, false, SCRIPT_TYPE.alterEntity, getId(collection));
 };
 
 /**
@@ -81,7 +82,7 @@ const getDeletedCommentOnCollectionScriptDto = collection => {
 	const isCollectionActivated = isContainerActivated && isObjectInDeltaModelActivated(collection);
 
 	const script = dropTableComment(tableName);
-	return AlterScriptDto.getInstance([script], isCollectionActivated, true);
+	return AlterScriptDto.getInstance(script, isCollectionActivated, true, SCRIPT_TYPE.alterEntity, getId(collection));
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
@@ -1,8 +1,13 @@
 const _ = require('lodash');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const { AlterIndexDto } = require('../../types/AlterIndexDto');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
-const { getSchemaNameFromCollection, getNamePrefixedWithSchemaName, wrapInQuotes } = require('../../../utils/general');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
+const {
+	getSchemaNameFromCollection,
+	getNamePrefixedWithSchemaName,
+	wrapInQuotes,
+	getId,
+} = require('../../../utils/general');
 const { dropIndex, createIndex, getWithOptions } = require('../../../ddlProvider/ddlHelpers/indexHelper');
 const assignTemplates = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -201,7 +206,13 @@ const getCreateIndexScriptDto = ({ index, collection, additionalDataForDdlProvid
 
 	const script = createIndex(tableName, indexForFeScript, dbData, isParentActivated);
 	const isIndexActivated = indexForFeScript.isActivated && isParentActivated;
-	return AlterScriptDto.getInstance([script], isIndexActivated, false);
+	return AlterScriptDto.getInstance(
+		script,
+		isIndexActivated,
+		false,
+		SCRIPT_TYPE.createEntityIndex,
+		getId(collection),
+	);
 };
 
 /**
@@ -238,13 +249,13 @@ const getAddedIndexesScriptDtos = ({ collection, additionalDataForDdlProvider })
  * @param {Object} additionalDataForDdlProvider
  * @return {AlterScriptDto | undefined}
  * */
-const getDeleteIndexScriptDto = ({ index, additionalDataForDdlProvider }) => {
+const getDeleteIndexScriptDto = ({ index, additionalDataForDdlProvider, collection }) => {
 	const { isParentActivated, schemaName } = additionalDataForDdlProvider;
 
 	const fullIndexName = getNamePrefixedWithSchemaName(index.indxName, schemaName);
 	const script = dropIndex({ indexName: fullIndexName });
 	const isIndexActivated = index.isActivated && isParentActivated;
-	return AlterScriptDto.getInstance([script], isIndexActivated, true);
+	return AlterScriptDto.getInstance(script, isIndexActivated, true, SCRIPT_TYPE.dropEntityIndex, getId(collection));
 };
 
 /**
@@ -267,7 +278,7 @@ const getDeletedIndexesScriptDtos = ({ collection, additionalDataForDdlProvider 
 			return !correspondingNewIndex;
 		})
 		.map(oldIndex => {
-			return getDeleteIndexScriptDto({ index: oldIndex, additionalDataForDdlProvider });
+			return getDeleteIndexScriptDto({ index: oldIndex, additionalDataForDdlProvider, collection });
 		})
 		.filter(Boolean);
 };
@@ -278,7 +289,7 @@ const getDeletedIndexesScriptDtos = ({ collection, additionalDataForDdlProvider 
  * @param {AlterIndexDto} oldIndex
  * @return {Array<AlterScriptDto>}
  * */
-const getAlterIndexScriptDtos = ({ newIndex, oldIndex, additionalDataForDdlProvider }) => {
+const getAlterIndexScriptDtos = ({ newIndex, oldIndex, additionalDataForDdlProvider, collection }) => {
 	const alterIndexScriptDtos = [];
 
 	const { isParentActivated, schemaName } = additionalDataForDdlProvider;
@@ -291,7 +302,13 @@ const getAlterIndexScriptDtos = ({ newIndex, oldIndex, additionalDataForDdlProvi
 			oldIndexName: oldIndex.indxName,
 			newIndexName: newIndex.indxName,
 		});
-		const renameScriptDto = AlterScriptDto.getInstance([script], isNewIndexActivated, false);
+		const renameScriptDto = AlterScriptDto.getInstance(
+			script,
+			isNewIndexActivated,
+			false,
+			SCRIPT_TYPE.alterEntityIndex,
+			getId(collection),
+		);
 		alterIndexScriptDtos.push(renameScriptDto);
 	}
 
@@ -302,7 +319,13 @@ const getAlterIndexScriptDtos = ({ newIndex, oldIndex, additionalDataForDdlProvi
 			indexName: newIndex.indxName,
 			tablespaceName: newIndex.index_tablespace_name,
 		});
-		const changeTablespaceScriptDto = AlterScriptDto.getInstance([script], isNewIndexActivated, false);
+		const changeTablespaceScriptDto = AlterScriptDto.getInstance(
+			script,
+			isNewIndexActivated,
+			false,
+			SCRIPT_TYPE.alterEntityIndex,
+			getId(collection),
+		);
 		alterIndexScriptDtos.push(changeTablespaceScriptDto);
 	}
 
@@ -314,9 +337,11 @@ const getAlterIndexScriptDtos = ({ newIndex, oldIndex, additionalDataForDdlProvi
 			index: newIndex,
 		});
 		const updateStorageParamsScriptDto = AlterScriptDto.getInstance(
-			[updateStorageParamsScript],
+			updateStorageParamsScript,
 			isNewIndexActivated,
 			false,
+			SCRIPT_TYPE.alterEntityIndex,
+			getId(collection),
 		);
 		alterIndexScriptDtos.push(updateStorageParamsScriptDto);
 
@@ -324,7 +349,13 @@ const getAlterIndexScriptDtos = ({ newIndex, oldIndex, additionalDataForDdlProvi
 			schemaName,
 			indexName: newIndex.indxName,
 		});
-		const reindexScriptDto = AlterScriptDto.getInstance([reindexScript], isNewIndexActivated, false);
+		const reindexScriptDto = AlterScriptDto.getInstance(
+			reindexScript,
+			isNewIndexActivated,
+			false,
+			SCRIPT_TYPE.alterEntityIndex,
+			getId(collection),
+		);
 		alterIndexScriptDtos.push(reindexScriptDto);
 	}
 
@@ -362,6 +393,7 @@ const getModifiedIndexesScriptDtos = ({ collection, additionalDataForDdlProvider
 			if (shouldDropAndRecreate) {
 				const deleteIndexScriptDto = getDeleteIndexScriptDto({
 					index: oldIndex,
+					collection,
 					additionalDataForDdlProvider,
 				});
 				const createIndexScriptDto = getCreateIndexScriptDto({
@@ -377,6 +409,7 @@ const getModifiedIndexesScriptDtos = ({ collection, additionalDataForDdlProvider
 				return getAlterIndexScriptDtos({
 					oldIndex,
 					newIndex,
+					collection,
 					additionalDataForDdlProvider,
 				});
 			}

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	AlterCollectionDto,
 	AlterCollectionColumnDto,
@@ -15,6 +15,7 @@ const {
 	wrapInQuotes,
 	isParentContainerActivated,
 	isObjectInDeltaModelActivated,
+	getId,
 } = require('../../../utils/general');
 const { alterKeyConstraint, dropKeyConstraint } = require('../../../ddlProvider/ddlHelpers/constraintsHelper');
 const { areConstraintOptionsEqual } = require('./areConstraintOptionsEqual');
@@ -677,7 +678,13 @@ const getModifyPkConstraintsScriptDtos = collection => {
 
 	return sortedAllDtos
 		.map(dto => {
-			return AlterScriptDto.getInstance([dto.script], dto.isActivated, dto.isDropScript);
+			return AlterScriptDto.getInstance(
+				dto.script,
+				dto.isActivated,
+				dto.isDropScript,
+				SCRIPT_TYPE.alterEntity,
+				getId(collection),
+			);
 		})
 		.filter(Boolean);
 };

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	AlterCollectionDto,
 	AlterCollectionColumnDto,
@@ -18,6 +18,7 @@ const {
 	wrapInQuotes,
 	isParentContainerActivated,
 	isObjectInDeltaModelActivated,
+	getId,
 } = require('../../../utils/general');
 const { areConstraintOptionsEqual } = require('./areConstraintOptionsEqual');
 
@@ -723,7 +724,13 @@ const getModifyUniqueKeyConstraintsScriptDtos = ({ collection, dbVersion }) => {
 
 	return sortedAllDtos
 		.map(dto => {
-			return AlterScriptDto.getInstance([dto.script], dto.isActivated, dto.isDropScript);
+			return AlterScriptDto.getInstance(
+				dto.script,
+				dto.isActivated,
+				dto.isDropScript,
+				SCRIPT_TYPE.alterEntity,
+				getId(collection),
+			);
 		})
 		.filter(Boolean);
 };

--- a/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/commentsHelper.js
@@ -1,9 +1,10 @@
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	getFullViewName,
 	wrapComment,
 	isObjectInDeltaModelActivated,
 	isParentContainerActivated,
+	getId,
 } = require('../../../utils/general');
 const assignTemplates = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -51,7 +52,7 @@ const getUpsertCommentsScriptDto = view => {
 		const isViewActivated = isContainerActivated && isObjectInDeltaModelActivated(view);
 
 		const script = updateViewComment(viewName, wrappedComment);
-		return AlterScriptDto.getInstance([script], isViewActivated, false);
+		return AlterScriptDto.getInstance(script, isViewActivated, false, SCRIPT_TYPE.alterView, getId(view));
 	}
 	return undefined;
 };
@@ -70,7 +71,7 @@ const getDropCommentsScriptDto = view => {
 		const isViewActivated = isContainerActivated && isObjectInDeltaModelActivated(view);
 
 		const script = dropViewComment(viewName);
-		return AlterScriptDto.getInstance([script], isViewActivated, true);
+		return AlterScriptDto.getInstance(script, isViewActivated, true, SCRIPT_TYPE.alterView, getId(view));
 	}
 	return undefined;
 };

--- a/forward_engineering/alterScript/types/AlterScriptDto.js
+++ b/forward_engineering/alterScript/types/AlterScriptDto.js
@@ -1,97 +1,71 @@
-class ModificationScript {
-	/**
-	 * @type string
-	 * */
-	script;
-
-	/**
-	 * @type boolean
-	 * */
-	isDropScript;
-}
+const SCRIPT_TYPE = /** @type {const} */ ({
+	createContainer: 'CREATE_CONTAINER',
+	dropContainer: 'DROP_CONTAINER',
+	alterContainer: 'ALTER_CONTAINER',
+	createEntity: 'CREATE_ENTITY',
+	dropEntity: 'DROP_ENTITY',
+	alterEntity: 'ALTER_ENTITY',
+	createView: 'CREATE_VIEW',
+	dropView: 'DROP_VIEW',
+	alterView: 'ALTER_VIEW',
+	createForeignKey: 'CREATE_FOREIGN_KEY',
+	dropForeignKey: 'DROP_FOREIGN_KEY',
+	createUDT: 'CREATE_UDT',
+	dropUDT: 'CREATE_UDT',
+	alterUDT: 'CREATE_UDT',
+	createEntityIndex: 'CREATE_ENTITY_INDEX',
+	dropEntityIndex: 'DROP_ENTITY_INDEX',
+	alterEntityIndex: 'ALTER_ENTITY_INDEX',
+});
 
 class AlterScriptDto {
 	/**
 	 * @type {boolean | undefined}
-	 * */
+	 */
 	isActivated;
 
 	/**
-	 * @type {Array<ModificationScript>}
+	 * @type {boolean}
 	 * */
-	scripts;
+	isDropScript;
 
 	/**
-	 * @param scripts {Array<string>}
-	 * @param isActivated {boolean}
-	 * @param isDropScripts {boolean}
-	 * @return {Array<AlterScriptDto>}
-	 * */
-	static getInstances(scripts, isActivated, isDropScripts) {
-		return (scripts || []).filter(Boolean).map(script => ({
-			isActivated,
-			scripts: [
-				{
-					isDropScript: isDropScripts,
-					script,
-				},
-			],
-		}));
-	}
+	 * @type {string}
+	 */
+	script;
 
 	/**
-	 * @param scripts {Array<string>}
-	 * @param isActivated {boolean}
-	 * @param isDropScripts {boolean}
+	 * @type {typeof SCRIPT_TYPE[keyof typeof SCRIPT_TYPE] | null}
+	 */
+	scriptType;
+
+	/**
+	 * @type {string | null}
+	 */
+	entityId;
+
+	/**
+	 * @param {string} script
+	 * @param {boolean} isActivated
+	 * @param {boolean} isDropScripts
 	 * @return {AlterScriptDto | undefined}
 	 * */
-	static getInstance(scripts, isActivated, isDropScripts) {
-		if (!scripts?.filter(Boolean)?.length) {
-			return undefined;
+	static getInstance(script, isActivated, isDropScript, scriptType, entityId) {
+		const cleanScript = script?.trim();
+		if (!cleanScript) {
+			return null;
 		}
 		return {
 			isActivated,
-			scripts: scripts.filter(Boolean).map(script => ({
-				isDropScript: isDropScripts,
-				script,
-			})),
-		};
-	}
-
-	/**
-	 * @param dropScript {string | undefined}
-	 * @param createScript {string | undefined}
-	 * @param isActivated {boolean}
-	 * @return {AlterScriptDto | undefined}
-	 * */
-	static getDropAndRecreateInstance(dropScript, createScript, isActivated) {
-		/**
-		 * @type {ModificationScript[]}
-		 * */
-		const scriptModificationDtos = [];
-		if (Boolean(dropScript)) {
-			scriptModificationDtos.push({
-				isDropScript: true,
-				script: dropScript,
-			});
-		}
-		if (Boolean(createScript)) {
-			scriptModificationDtos.push({
-				isDropScript: false,
-				script: createScript,
-			});
-		}
-		if (!scriptModificationDtos?.length) {
-			return undefined;
-		}
-		return {
-			isActivated,
-			scripts: scriptModificationDtos,
+			isDropScript,
+			script: cleanScript,
+			scriptType,
+			entityId,
 		};
 	}
 }
 
 module.exports = {
-	ModificationScript,
 	AlterScriptDto,
+	SCRIPT_TYPE,
 };

--- a/forward_engineering/utils/general.js
+++ b/forward_engineering/utils/general.js
@@ -290,6 +290,8 @@ const isParentContainerActivated = collection => {
 	);
 };
 
+const getId = entity => entity.id || entity.role.id;
+
 module.exports = {
 	getDbName,
 	getDbData,
@@ -324,4 +326,5 @@ module.exports = {
 	addCommaPrefix,
 	isObjectInDeltaModelActivated,
 	isParentContainerActivated,
+	getId,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14860" title="HCK-14860" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14860</a>  [PostgreSQL]: ALTER script with custom hooks
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Update the `ALTER` script generation flow to support returning an array of SQL statements instead of a single concatenated script. This will allow the studio to manage the script output, such as injecting custom scripts.

The same has already been done for the Oracle plugin.