### PR TITLE
HCK-16957: validate empty check on column 

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -711,7 +711,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -1353,7 +1356,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -1956,7 +1962,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -2598,7 +2607,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -2772,7 +2784,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -3352,7 +3367,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -3961,7 +3979,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -4203,7 +4224,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -4784,7 +4808,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -5373,7 +5400,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -5983,7 +6013,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -6226,7 +6259,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -6371,7 +6407,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -6537,7 +6576,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -6702,7 +6744,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -6784,7 +6829,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -6844,7 +6892,10 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "No inherit",
@@ -7006,7 +7057,10 @@ making sure that you maintain a proper JSON format.
 						"propertyKeyword": "expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
+						"markdown": false,
+						"validation": {
+							"required": true
+						}
 					}
 				]
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-16957" title="HCK-16957" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-16957</a>  [PostgreSQL][Yugabyte] Column-level check constraint empty expression validation incorrectly absent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

* marked column level "Check Constraints" expression as required