### PR TITLE
chore: address Trivy production dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "PostgreSQL",
-    "version": "0.2.49",
+    "version": "0.2.50",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "PostgreSQL",
-            "version": "0.2.49",
+            "version": "0.2.50",
             "dependencies": {
                 "lodash": "4.18.1",
                 "pg": "8.12.0"
@@ -1236,16 +1236,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
         "pg": "8.12.0"
     },
     "overrides": {
-        "minimatch": "10.2.4"
+        "minimatch": "10.2.4",
+        "brace-expansion": "5.0.8"
     }
 }


### PR DESCRIPTION
## Summary
- Address Trivy dependency vulnerabilities for `PostgreSQL`: brace-expansion override 5.0.6 → 5.0.8 (and package-lock refresh).
- Not listed as production-impacted in the Trivy report; updated for the same vulnerable transitive versions present in the lockfile (including non-production trees).
- Reference: https://teamcity.hackolade.com/buildConfiguration/Plugins_Build/284434

## Test plan
- [ ] CI passes
- [ ] Plugins develop Trivy re-scan no longer reports the fixed packages for production-impacted plugins
